### PR TITLE
Provide built-in facilities for incremental analyses

### DIFF
--- a/analysis-runner/src/main/scala/org/anon/spareuse/execution/AnalysisRunner.scala
+++ b/analysis-runner/src/main/scala/org/anon/spareuse/execution/AnalysisRunner.scala
@@ -263,7 +263,7 @@ class AnalysisRunner(private[execution] val configuration: AnalysisRunnerConfig)
 
             val freshResults = results.collect{
               case FreshResult(content, affectedEntities) =>
-                AnalysisResultData(resultUuidIt.next(), isRevoked = false, content, affectedEntities)
+                AnalysisResultData(resultUuidIt.next(), isRevoked = false, cmd.associatedRunId, content, affectedEntities)
             }
 
             val unchangedResultIds = results.collect{

--- a/analysis-runner/src/main/scala/org/anon/spareuse/execution/AnalysisRunner.scala
+++ b/analysis-runner/src/main/scala/org/anon/spareuse/execution/AnalysisRunner.scala
@@ -115,8 +115,14 @@ class AnalysisRunner(private[execution] val configuration: AnalysisRunnerConfig)
                 val baselineRun = if(baselineRunId.isBlank) None
                 else {
                   if(dataAccessor.hasAnalysisRun(analysisName, analysisVersion, baselineRunId)){
-                    //TODO: Are the associatedInputs for results fully resolved by data accessor? No!
-                    Some(dataAccessor.getAnalysisRun(analysisName, analysisVersion, baselineRunId, includeResults = true).get)
+
+                    // Make sure the run that we pass to the analysis as a baseline has fully resolved entity hierarchies
+                    val theRun = dataAccessor
+                      .getAnalysisRun(analysisName, analysisVersion, baselineRunId, includeResults = true)
+                      .get
+                      .withResolvedGenerics( uid => dataAccessor.getEntity(uid).get , forceResolve = true)
+
+                    Some(theRun)
                   } else
                     throw new AnalysisRunNotPossibleException(s"Baseline run ID invalid: " + baselineRunId, command)
                 }

--- a/analysis-runner/src/main/scala/org/anon/spareuse/execution/AnalysisRunner.scala
+++ b/analysis-runner/src/main/scala/org/anon/spareuse/execution/AnalysisRunner.scala
@@ -9,7 +9,7 @@ import org.anon.spareuse.core.utils.rabbitmq.{MqMessageWriter, MqStreamIntegrati
 import org.anon.spareuse.execution.utils.{AnalysisRunNotPossibleException, ValidRunnerCommand, ValidStartRunCommand}
 import org.anon.spareuse.core.formats.json.CustomObjectWriter
 import org.anon.spareuse.core.maven.MavenIdentifier
-import org.anon.spareuse.core.model.analysis.RunnerCommand
+import org.anon.spareuse.core.model.analysis.{AnalysisCommand, IncrementalAnalysisCommand, RunnerCommand}
 import org.anon.spareuse.core.storage.DataAccessor
 import org.anon.spareuse.core.storage.postgresql.PostgresDataAccessor
 import org.anon.spareuse.core.utils.http
@@ -36,15 +36,15 @@ class AnalysisRunner(private[execution] val configuration: AnalysisRunnerConfig)
 
   override def initialize(): Unit = {
 
-    AnalysisRegistry.registerAnalysisImplementation(new MvnConstantClassAnalysisImpl)
-    AnalysisRegistry.registerAnalysisImplementation(new MvnDependencyAnalysisImpl)
-    AnalysisRegistry.registerAnalysisImplementation(new MvnPartialCallgraphAnalysisImpl)
+    AnalysisRegistry.registerRegularAnalysis(MvnConstantClassAnalysisImpl, () => new MvnConstantClassAnalysisImpl)
+    AnalysisRegistry.registerRegularAnalysis(MvnDependencyAnalysisImpl, () => new MvnDependencyAnalysisImpl)
+    AnalysisRegistry.registerRegularAnalysis(MvnPartialCallgraphAnalysisImpl, () => new MvnPartialCallgraphAnalysisImpl)
 
     entityQueueWriter.initialize()
 
     dataAccessor.initialize()
 
-    AnalysisRegistry.allAnalysisImplementations().foreach(d => dataAccessor.registerIfNotPresent(d.analysisData))
+    AnalysisRegistry.allAnalysisDescriptors().foreach(d => dataAccessor.registerIfNotPresent(d.analysisData))
   }
 
   override def shutdown(): Unit = {
@@ -107,9 +107,36 @@ class AnalysisRunner(private[execution] val configuration: AnalysisRunnerConfig)
           if (!dataAccessor.hasAnalysisRun(analysisName, analysisVersion, command.associatedRunId))
             throw new AnalysisRunNotPossibleException("Designated run id not in DB: " + command.associatedRunId, command)
 
+          // Check whether an implementation is registered and return a new implementation instance
+          val implementationOpt = command match {
+            case IncrementalAnalysisCommand(_, _, _, _, _, baselineRunId) =>
+              if (AnalysisRegistry.hasIncrementalAnalysisImplementation(analysisName, analysisVersion)) {
+
+                val baselineRun = if(baselineRunId.isBlank) None
+                else {
+                  if(dataAccessor.hasAnalysisRun(analysisName, analysisVersion, baselineRunId)){
+                    //TODO: Are the associatedInputs for results fully resolved by data accessor? No!
+                    Some(dataAccessor.getAnalysisRun(analysisName, analysisVersion, baselineRunId, includeResults = true).get)
+                  } else
+                    throw new AnalysisRunNotPossibleException(s"Baseline run ID invalid: " + baselineRunId, command)
+                }
+
+                Some(AnalysisRegistry.getIncrementalAnalysisImplementation(analysisName, analysisVersion, baselineRun))
+              } else None
+
+            case _: AnalysisCommand =>
+              if (AnalysisRegistry.hasRegularAnalysisImplementation(analysisName, analysisVersion))
+                Some(AnalysisRegistry.getRegularAnalysisImplementation(analysisName, analysisVersion))
+              else None
+
+            case _ =>
+              None
+
+          }
+
           // Assert that the required analysis implementation is available. This is the fastest requirement to check.
-          if (AnalysisRegistry.analysisImplementationAvailable(analysisName, analysisVersion)) {
-            val theAnalysisImpl = AnalysisRegistry.getAnalysisImplementation(analysisName, analysisVersion)
+          if (implementationOpt.isDefined) {
+            val theAnalysisImpl = implementationOpt.get
 
             // Check that analysis is registered in DB. Should always be the case
             ensureAnalysisIsRegistered(analysisName, analysisVersion)
@@ -132,7 +159,7 @@ class AnalysisRunner(private[execution] val configuration: AnalysisRunnerConfig)
               if (!isValidName) {
                 log.warn("Input is not a valid entity name: " + n)
 
-                if (!theAnalysisImpl.inputBatchProcessing)
+                if (!theAnalysisImpl.descriptor.inputBatchProcessing)
                   throw new AnalysisRunNotPossibleException("Set of inputs contains an invalid entity name that can never be resolved: " + n, command)
               }
 
@@ -141,7 +168,7 @@ class AnalysisRunner(private[execution] val configuration: AnalysisRunnerConfig)
 
 
             if (entityNamesToQueue.nonEmpty) {
-              val deferredAnalysisCommand = if(!theAnalysisImpl.inputBatchProcessing || namesToProcess.diff(entityNamesNotIndexed).isEmpty) command// If no current run is executed, we do not need to generate a second run UID
+              val deferredAnalysisCommand = if(!theAnalysisImpl.descriptor.inputBatchProcessing || namesToProcess.diff(entityNamesNotIndexed).isEmpty) command// If no current run is executed, we do not need to generate a second run UID
               else {
                 //If the current run is 'split into two', we need to generate a new run UID for the deferred analysis execution
                 val emptyRunId = dataAccessor.storeEmptyAnalysisRun(analysisName, analysisVersion, command.configurationRaw).get
@@ -153,7 +180,7 @@ class AnalysisRunner(private[execution] val configuration: AnalysisRunnerConfig)
 
               entityQueueWriter.appendToQueue(minerCommand.toJson.compactPrint, Some(2))
 
-              if (!theAnalysisImpl.inputBatchProcessing) {
+              if (!theAnalysisImpl.descriptor.inputBatchProcessing) {
                 log.warn("Analysis will be rescheduled once input mining is done.")
                 return None
               }
@@ -174,7 +201,7 @@ class AnalysisRunner(private[execution] val configuration: AnalysisRunnerConfig)
             }
 
             // Download entity information for the analysis from the DB
-            Try(namesToProcess.map(name => dataAccessor.getEntity(name, theAnalysisImpl.inputEntityKind, theAnalysisImpl.requiredInputResolutionLevel).get)) match {
+            Try(namesToProcess.map(name => dataAccessor.getEntity(name, theAnalysisImpl.descriptor.inputEntityKind, theAnalysisImpl.descriptor.requiredInputResolutionLevel).get)) match {
               case Success(entities) =>
                 // Finally check that the analysis can in fact be executed with those parameters
                 if (theAnalysisImpl.executionPossible(entities.toSeq, command.configurationRaw)) {
@@ -221,12 +248,12 @@ class AnalysisRunner(private[execution] val configuration: AnalysisRunnerConfig)
           case Success(results) =>
             log.info(s"Analysis execution finished with ${results.size} results.")
 
-            val serializer = new CustomObjectWriter(analysisImpl.analysisData.resultFormat)
+            val serializer = new CustomObjectWriter(analysisImpl.descriptor.analysisData.resultFormat)
 
             val resultUuidIt = dataAccessor.getFreshResultUuids(results.size).iterator
 
             val runResults = results.map{ res => AnalysisResultData(resultUuidIt.next(), isRevoked = false, res.content, res.affectedEntities) }
-
+            // TODO: Connect to unchanged results for incremental analyses?
             val runLogs = analysisImpl.getLogs
 
             val dbRunId = cmd.associatedRunId
@@ -278,14 +305,14 @@ class AnalysisRunner(private[execution] val configuration: AnalysisRunnerConfig)
   }
 
   private def getEntityNamesNotInDb(inputEntityNames: Set[String], analysisImpl: AnalysisImplementation): Set[String] = {
-    inputEntityNames.filterNot(name => dataAccessor.hasEntity(name, analysisImpl.inputEntityKind))
+    inputEntityNames.filterNot(name => dataAccessor.hasEntity(name, analysisImpl.descriptor.inputEntityKind))
   }
 
 
   private def filterUnprocessedEntityNames(inputEntityNames: Set[String], analysisImpl: AnalysisImplementation)(implicit cmd: RunnerCommand): Set[String] = {
-    dataAccessor.getAnalysisRuns(analysisImpl.name, analysisImpl.version) match {
+    dataAccessor.getAnalysisRuns(analysisImpl.descriptor.name, analysisImpl.descriptor.version) match {
       case Success(runData) =>
-        if (analysisImpl.inputBatchProcessing) {
+        if (analysisImpl.descriptor.inputBatchProcessing) {
           val allInputsProcessed = runData
             .filter(_.state.equals(RunState.Finished)) // Only consider non-failed runs!
             .flatMap(_.inputs.map(_.uid))

--- a/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/AnalysisImplementation.scala
+++ b/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/AnalysisImplementation.scala
@@ -29,7 +29,7 @@ trait AnalysisImplementation extends MavenReleaseListDiscovery {
    * Specifies whether this analysis processes the set of inputs one after another (batch processing) or the set of
    * inputs as-a-whole. If set to true, the runner can optimize and remove redundant inputs before execution.
    */
-  val inputBatchProcessing: Boolean
+  final lazy val inputBatchProcessing: Boolean = analysisData.doesBatchProcessing
 
   /**
    * Specifies how deep the input entity structure needs to be, i.e. how much information the analysis needs

--- a/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/AnalysisImplementation.scala
+++ b/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/AnalysisImplementation.scala
@@ -5,6 +5,7 @@ import org.anon.spareuse.core.model.{AnalysisData, SoftwareEntityKind}
 import org.anon.spareuse.core.model.SoftwareEntityKind.SoftwareEntityKind
 import org.anon.spareuse.core.model.entities.JavaEntities._
 import org.anon.spareuse.core.model.entities.SoftwareEntityData
+import org.anon.spareuse.core.storage.AnalysisAccessor
 import org.slf4j.{Logger, LoggerFactory}
 
 import java.io.InputStream
@@ -21,7 +22,7 @@ trait AnalysisImplementation extends MavenReleaseListDiscovery {
 
   def executionPossible(inputs: Seq[SoftwareEntityData], rawConfig: String): Boolean
 
-  def executeAnalysis(inputs: Seq[SoftwareEntityData], rawConfig: String): Try[Set[Result]]
+  def executeAnalysis(inputs: Seq[SoftwareEntityData], rawConfig: String): Try[Set[AnalysisResult]]
 
   protected def getFilesFor(jl: JavaLibrary): Try[Map[String, InputStream]] = Try {
     val ga = jl.name

--- a/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/AnalysisImplementation.scala
+++ b/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/AnalysisImplementation.scala
@@ -17,25 +17,7 @@ trait AnalysisImplementation extends MavenReleaseListDiscovery {
   private val internalLog: Logger = LoggerFactory.getLogger(getClass)
   protected val log: PersistingLogger = new PersistingLogger
 
-  val analysisData: AnalysisData
-
-  lazy val name: String = analysisData.name
-  lazy val version: String = analysisData.version
-
-  lazy val inputEntityKind: SoftwareEntityKind = analysisData.inputKind
-
-
-  /**
-   * Specifies whether this analysis processes the set of inputs one after another (batch processing) or the set of
-   * inputs as-a-whole. If set to true, the runner can optimize and remove redundant inputs before execution.
-   */
-  final lazy val inputBatchProcessing: Boolean = analysisData.doesBatchProcessing
-
-  /**
-   * Specifies how deep the input entity structure needs to be, i.e. how much information the analysis needs
-   * from the database. By default, entities will be resolved until the Method level (thus excluding instructions).
-   */
-  val requiredInputResolutionLevel: SoftwareEntityKind = SoftwareEntityKind.Method
+  val descriptor: AnalysisImplementationDescriptor
 
   def executionPossible(inputs: Seq[SoftwareEntityData], rawConfig: String): Boolean
 
@@ -129,5 +111,30 @@ trait AnalysisImplementation extends MavenReleaseListDiscovery {
     def getLogs: Seq[String] = logs
 
   }
+}
 
+trait AnalysisImplementationDescriptor {
+
+  val analysisData: AnalysisData
+
+  lazy val name: String = analysisData.name
+  lazy val version: String = analysisData.version
+  lazy val fullName: String = s"$name:$version"
+
+  lazy val inputEntityKind: SoftwareEntityKind = analysisData.inputKind
+
+  lazy val isIncremental: Boolean = analysisData.isIncremental
+
+
+  /**
+   * Specifies whether this analysis processes the set of inputs one after another (batch processing) or the set of
+   * inputs as-a-whole. If set to true, the runner can optimize and remove redundant inputs before execution.
+   */
+  final lazy val inputBatchProcessing: Boolean = analysisData.doesBatchProcessing
+
+  /**
+   * Specifies how deep the input entity structure needs to be, i.e. how much information the analysis needs
+   * from the database. By default, entities will be resolved until the Method level (thus excluding instructions).
+   */
+  val requiredInputResolutionLevel: SoftwareEntityKind = SoftwareEntityKind.Method
 }

--- a/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/AnalysisRegistry.scala
+++ b/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/AnalysisRegistry.scala
@@ -1,22 +1,50 @@
 package org.anon.spareuse.execution.analyses
 
+import org.anon.spareuse.core.model.AnalysisRunData
+
 import scala.collection.mutable
 
 object AnalysisRegistry {
 
-  private val analysisLookup:  mutable.Map[String, AnalysisImplementation] = new mutable.HashMap()
+  private val analysisLookup:  mutable.Map[String, AnalysisImplementationDescriptor] = new mutable.HashMap()
+
+  private val regularAnalysisLookup: mutable.Map[String, () => AnalysisImplementation] = new mutable.HashMap()
+  private val incrementalAnalysisLookup: mutable.Map[String, Option[AnalysisRunData] => AnalysisImplementation] = new mutable.HashMap()
 
   private def combine(str1: String, str2: String) = s"$str1:$str2"
+  def registerRegularAnalysis(descriptor: AnalysisImplementationDescriptor, creator: () => AnalysisImplementation): Unit = {
+    if(!hasAnalysisImplementation(descriptor)) {
+      assert(!descriptor.isIncremental)
+      analysisLookup.put(descriptor.fullName, descriptor)
+      regularAnalysisLookup.put(descriptor.fullName, creator)
+    } else
+      throw new IllegalStateException(s"Duplicate Analysis registration: ${descriptor.fullName} already exists")
+  }
 
-  def registerAnalysisImplementation(analysisImpl: AnalysisImplementation): Unit =
-    analysisLookup.put(combine(analysisImpl.name, analysisImpl.version), analysisImpl)
+  def registerIncrementalAnalysis(descriptor: AnalysisImplementationDescriptor, creator: Option[AnalysisRunData] => AnalysisImplementation): Unit = {
+    if(!hasAnalysisImplementation(descriptor)) {
+      assert(descriptor.isIncremental)
+      analysisLookup.put(descriptor.fullName, descriptor)
+      incrementalAnalysisLookup.put(descriptor.fullName, creator)
+    } else
+      throw new IllegalStateException(s"Duplicate Analysis registration: ${descriptor.fullName} already exists")
+  }
 
-  def analysisImplementationAvailable(analysisName: String, analysisVersion: String): Boolean =
-    analysisLookup.contains(combine(analysisName, analysisVersion))
+  private def hasAnalysisImplementation(descriptor: AnalysisImplementationDescriptor): Boolean = analysisLookup.contains(descriptor.fullName)
 
-  def getAnalysisImplementation(analysisName: String, analysisVersion: String): AnalysisImplementation =
-    analysisLookup(combine(analysisName, analysisVersion))
+  def hasRegularAnalysisImplementation(analysisName: String, analysisVersion: String): Boolean =
+    regularAnalysisLookup.contains(combine(analysisName, analysisVersion))
 
-  def allAnalysisImplementations(): Iterable[AnalysisImplementation] = analysisLookup.values
+  def hasIncrementalAnalysisImplementation(analysisName: String, analysisVersion: String): Boolean =
+    incrementalAnalysisLookup.contains(combine(analysisName, analysisVersion))
+
+  def getRegularAnalysisImplementation(analysisName: String, analysisVersion: String): AnalysisImplementation =
+    regularAnalysisLookup(combine(analysisName, analysisVersion))()
+
+  def getIncrementalAnalysisImplementation(analysisName: String, analysisVersion: String, baseline: Option[AnalysisRunData]): AnalysisImplementation = {
+    incrementalAnalysisLookup(combine(analysisName, analysisVersion))(baseline)
+  }
+
+  def allAnalysisDescriptors(): Iterable[AnalysisImplementationDescriptor] = analysisLookup.values
 
 }

--- a/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/IncrementalAnalysisImplementation.scala
+++ b/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/IncrementalAnalysisImplementation.scala
@@ -1,0 +1,9 @@
+package org.anon.spareuse.execution.analyses
+
+import org.anon.spareuse.core.model.AnalysisRunData
+
+abstract class IncrementalAnalysisImplementation(protected val baselineRunOpt: Option[AnalysisRunData]) extends AnalysisImplementation {
+
+
+
+}

--- a/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/IncrementalAnalysisImplementation.scala
+++ b/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/IncrementalAnalysisImplementation.scala
@@ -1,9 +1,78 @@
 package org.anon.spareuse.execution.analyses
 
-import org.anon.spareuse.core.model.AnalysisRunData
+import org.anon.spareuse.core.model.{AnalysisResultData, AnalysisRunData}
+import org.anon.spareuse.core.model.entities.SoftwareEntityData
+
+import scala.util.Try
 
 abstract class IncrementalAnalysisImplementation(protected val baselineRunOpt: Option[AnalysisRunData]) extends AnalysisImplementation {
 
+  override def executeAnalysis(inputs: Seq[SoftwareEntityData], rawConfig: String): Try[Set[Result]] = {
+    baselineRunOpt match {
+      case Some(baselineRun) =>
+        log.info(s"Running incremental analysis ${descriptor.fullName} with baseline run ${baselineRun.uid}")
 
+        val splitExecutions = baselineRun
+          .results
+          .flatMap{ previousResult =>
+            val currentEntitiesAffected = inputs.filter(currEnt => previousResult.affectedEntities.exists( prevEnt => isValidBaselineFor(prevEnt, currEnt)))
+
+            if(currentEntitiesAffected.size == previousResult.affectedEntities.size) Some((previousResult, currentEntitiesAffected))
+            else None
+          }
+
+        val inputsWithNoBaseline = inputs.diff(splitExecutions.flatMap(_._2).toSeq)
+
+        log.info(s"Finished building execution plan for incremental analysis.")
+        log.info(s"--- #Runs with baseline results: ${splitExecutions.size}")
+        log.info(s"--- #Entities with no baseline: ${inputsWithNoBaseline.size}")
+        log.info("")
+
+        val noOfRuns = splitExecutions.size + (if (inputsWithNoBaseline.nonEmpty) 1 else 0)
+        var currentRun = 1
+
+        Try{
+          splitExecutions.flatMap {
+              case (baselineResult: AnalysisResultData, currentInputs) =>
+                log.info(s"[RUN $currentRun / $noOfRuns] Incremental computation with ${currentInputs.size} inputs for result ${baselineResult.uid}")
+                currentRun += 1
+                executeIncremental(currentInputs, Some(baselineResult)).get
+
+            } ++ {
+            if(inputsWithNoBaseline.nonEmpty){
+              log.info(s"[RUN $currentRun / $noOfRuns] Incremental computation without baseline for ${inputsWithNoBaseline.size} inputs")
+              executeIncremental(inputsWithNoBaseline, None).get
+            } else {
+              Set.empty
+            }
+
+          }
+        }
+      case None =>
+        log.info(s"Running incremental analysis ${descriptor.fullName} with empty baseline.")
+        executeIncremental(inputs, None)
+    }
+  }
+
+
+  protected def isValidBaselineFor(potentialBaseline: SoftwareEntityData, current: SoftwareEntityData): Boolean = {
+    // Results must be valid for *part of a library* - not the library itself - to be used for incremental analysis
+    if(potentialBaseline.isLibrary || current.isLibrary) false
+    // Results must refer to entities of the same kind to be used for incremental computations
+    else if(potentialBaseline.kind != current.kind) false
+    // Results must belong to entities of the same library to be used for incremental computations
+    // Note: No check for subsequent version numbers here, any result for the same library may be used
+    else {
+      val baselineProgram = potentialBaseline.findFirstParent(_.isLibrary)
+      val currentProgramOpt = current.findFirstParent(_.isLibrary)
+
+      baselineProgram.isDefined &&
+        currentProgramOpt.isDefined &&
+        baselineProgram.get.uid.equals(currentProgramOpt.get.uid)
+    }
+  }
+
+
+  def executeIncremental(inputs: Seq[SoftwareEntityData], previousResult: Option[AnalysisResultData]): Try[Set[Result]]
 
 }

--- a/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/IncrementalAnalysisImplementation.scala
+++ b/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/IncrementalAnalysisImplementation.scala
@@ -7,7 +7,7 @@ import scala.util.{Success, Try}
 
 abstract class IncrementalAnalysisImplementation(protected val baselineRunOpt: Option[AnalysisRunData]) extends AnalysisImplementation {
 
-  override def executeAnalysis(inputs: Seq[SoftwareEntityData], rawConfig: String): Try[Set[Result]] = {
+  override def executeAnalysis(inputs: Seq[SoftwareEntityData], rawConfig: String): Try[Set[AnalysisResult]] = {
     baselineRunOpt match {
       case Some(baselineRun) =>
         log.info(s"Running incremental analysis ${descriptor.fullName} with baseline run ${baselineRun.uid}")
@@ -77,6 +77,6 @@ abstract class IncrementalAnalysisImplementation(protected val baselineRunOpt: O
   }
 
 
-  def executeIncremental(inputs: Seq[SoftwareEntityData], previousResult: Option[AnalysisResultData]): Try[Set[Result]]
+  def executeIncremental(inputs: Seq[SoftwareEntityData], previousResult: Option[AnalysisResultData]): Try[Set[AnalysisResult]]
 
 }

--- a/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/IncrementalAnalysisImplementation.scala
+++ b/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/IncrementalAnalysisImplementation.scala
@@ -62,17 +62,19 @@ abstract class IncrementalAnalysisImplementation(protected val baselineRunOpt: O
   protected def isValidBaselineFor(potentialBaseline: SoftwareEntityData, current: SoftwareEntityData): Boolean = {
     // Results must be valid for *part of a library* - not the library itself - to be used for incremental analysis
     if(potentialBaseline.isLibrary || current.isLibrary) false
-    // Results must refer to entities of the same kind to be used for incremental computations
-    else if(potentialBaseline.kind != current.kind) false
+    // Results must refer to entities of the same kind and same name to be used for incremental computations
+    else if(potentialBaseline.kind != current.kind || potentialBaseline.name != current.name) false
     // Results must belong to entities of the same library to be used for incremental computations
     // Note: No check for subsequent version numbers here, any result for the same library may be used
     else {
-      val baselineProgram = potentialBaseline.findFirstParent(_.isLibrary)
-      val currentProgramOpt = current.findFirstParent(_.isLibrary)
+      val baselineLibrary = potentialBaseline.findFirstParent(_.isLibrary)
+      val currentLibrary = current.findFirstParent(_.isLibrary)
 
-      baselineProgram.isDefined &&
-        currentProgramOpt.isDefined &&
-        baselineProgram.get.uid.equals(currentProgramOpt.get.uid)
+      //TODO: This will need some deeper equality testing to make sure results for 'foo(Bar b)' are not registered as valid for 'foo()', etc.
+
+      baselineLibrary.isDefined &&
+        currentLibrary.isDefined &&
+        baselineLibrary.get.uid.equals(currentLibrary.get.uid)
     }
   }
 

--- a/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/IncrementalAnalysisImplementation.scala
+++ b/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/IncrementalAnalysisImplementation.scala
@@ -3,7 +3,7 @@ package org.anon.spareuse.execution.analyses
 import org.anon.spareuse.core.model.{AnalysisResultData, AnalysisRunData}
 import org.anon.spareuse.core.model.entities.SoftwareEntityData
 
-import scala.util.Try
+import scala.util.{Success, Try}
 
 abstract class IncrementalAnalysisImplementation(protected val baselineRunOpt: Option[AnalysisRunData]) extends AnalysisImplementation {
 
@@ -48,9 +48,13 @@ abstract class IncrementalAnalysisImplementation(protected val baselineRunOpt: O
 
           }
         }
-      case None =>
+      case None if inputs.nonEmpty =>
         log.info(s"Running incremental analysis ${descriptor.fullName} with empty baseline.")
         executeIncremental(inputs, None)
+
+      case _ =>
+        log.info(s"No inputs supplied, analysis ${descriptor.fullName} will not be executed.")
+        Success(Set.empty)
     }
   }
 

--- a/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/Result.scala
+++ b/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/Result.scala
@@ -2,4 +2,13 @@ package org.anon.spareuse.execution.analyses
 
 import org.anon.spareuse.core.model.entities.SoftwareEntityData
 
-case class Result(content: Object, affectedEntities: Set[SoftwareEntityData])
+trait AnalysisResult {
+  val isFresh: Boolean
+}
+
+case class ExistingResult(resultUid: String) extends AnalysisResult {
+  override val isFresh = false
+}
+case class FreshResult(content: Object, affectedEntities: Set[SoftwareEntityData]) extends AnalysisResult {
+  override val isFresh: Boolean = true
+}

--- a/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/impl/MvnConstantClassAnalysisImpl.scala
+++ b/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/impl/MvnConstantClassAnalysisImpl.scala
@@ -7,40 +7,18 @@ import org.anon.spareuse.core.model.SoftwareEntityKind.SoftwareEntityKind
 import org.anon.spareuse.core.model.entities.JavaEntities.{JavaClass, JavaLibrary}
 import org.anon.spareuse.core.model.entities.SoftwareEntityData
 import org.anon.spareuse.core.utils.toHex
-import org.anon.spareuse.execution.analyses.{AnalysisImplementation, Result}
+import org.anon.spareuse.execution.analyses.{AnalysisImplementation, AnalysisImplementationDescriptor, Result}
 
 import scala.collection.mutable
 import scala.util.Try
 
 class MvnConstantClassAnalysisImpl extends AnalysisImplementation {
 
-  private val resultFormat = MapResultFormat(
-    formats.StringFormat,
-    ObjectResultFormat(Set(
-      NamedPropertyFormat("noOfOccurrences", NumberFormat, "Number of library releases this class was present in."),
-      NamedPropertyFormat("noOfUniqueOccurrences", NumberFormat, "Number of unique versions this class had in its history.")
-    )),
-    keyExplanation = "Fully qualified class name for every class in the history of this library",
-    valueExplanation = "Constancy information on this class"
-  )
-
-  override val analysisData: AnalysisData = AnalysisData.systemAnalysis(
-    "mvn-constant-classes",
-    "1.0.0",
-    "Analysis that processes a Maven library (GA-Tuple) and computes the number of times each class appears in a release, as well as the number of unique versions of every class. MD5 is used to derive class equality.",
-    "Scala, built-in facilities",
-    Set("java", "scala"),
-    resultFormat,
-    SoftwareEntityKind.Library,
-    doesBatchProcessing = true,
-    isIncremental = false
-  )
-
-  override val requiredInputResolutionLevel: SoftwareEntityKind = SoftwareEntityKind.Class
+  override val descriptor: AnalysisImplementationDescriptor = MvnConstantClassAnalysisImpl
 
   override def executionPossible(inputs: Seq[SoftwareEntityData], rawConfig: String): Boolean = {
     if (inputs.exists(e => !e.isInstanceOf[JavaLibrary])) {
-      log.warn(s"Execution of analysis $name:$version not possible: Inputs must be of kind 'Library'")
+      log.warn(s"Execution of analysis ${descriptor.fullName} not possible: Inputs must be of kind 'Library'")
       false
     } else {
       true
@@ -84,4 +62,33 @@ class MvnConstantClassAnalysisImpl extends AnalysisImplementation {
   }
 
   case class ClassCountResult(noOfOccurrences: Int, noOfUniqueOccurrences: Int)
+}
+
+object MvnConstantClassAnalysisImpl extends AnalysisImplementationDescriptor {
+
+  private val resultFormat = MapResultFormat(
+    formats.StringFormat,
+    ObjectResultFormat(Set(
+      NamedPropertyFormat("noOfOccurrences", NumberFormat, "Number of library releases this class was present in."),
+      NamedPropertyFormat("noOfUniqueOccurrences", NumberFormat, "Number of unique versions this class had in its history.")
+    )),
+    keyExplanation = "Fully qualified class name for every class in the history of this library",
+    valueExplanation = "Constancy information on this class"
+  )
+
+  override val analysisData: AnalysisData = AnalysisData.systemAnalysis(
+    "mvn-constant-classes",
+    "1.0.0",
+    "Analysis that processes a Maven library (GA-Tuple) and computes the number of times each class appears in a release, as well as the number of unique versions of every class. MD5 is used to derive class equality.",
+    "Scala, built-in facilities",
+    Set("java", "scala"),
+    resultFormat,
+    SoftwareEntityKind.Library,
+    doesBatchProcessing = true,
+    isIncremental = false
+  )
+
+  override val requiredInputResolutionLevel: SoftwareEntityKind = SoftwareEntityKind.Class
+
+
 }

--- a/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/impl/MvnConstantClassAnalysisImpl.scala
+++ b/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/impl/MvnConstantClassAnalysisImpl.scala
@@ -29,9 +29,12 @@ class MvnConstantClassAnalysisImpl extends AnalysisImplementation {
     "1.0.0",
     "Analysis that processes a Maven library (GA-Tuple) and computes the number of times each class appears in a release, as well as the number of unique versions of every class. MD5 is used to derive class equality.",
     "Scala, built-in facilities",
-    Set("java", "scala"),  resultFormat, SoftwareEntityKind.Library)
-
-  override val inputBatchProcessing: Boolean = true
+    Set("java", "scala"),
+    resultFormat,
+    SoftwareEntityKind.Library,
+    doesBatchProcessing = true,
+    isIncremental = false
+  )
 
   override val requiredInputResolutionLevel: SoftwareEntityKind = SoftwareEntityKind.Class
 

--- a/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/impl/MvnConstantClassAnalysisImpl.scala
+++ b/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/impl/MvnConstantClassAnalysisImpl.scala
@@ -7,7 +7,7 @@ import org.anon.spareuse.core.model.SoftwareEntityKind.SoftwareEntityKind
 import org.anon.spareuse.core.model.entities.JavaEntities.{JavaClass, JavaLibrary}
 import org.anon.spareuse.core.model.entities.SoftwareEntityData
 import org.anon.spareuse.core.utils.toHex
-import org.anon.spareuse.execution.analyses.{AnalysisImplementation, AnalysisImplementationDescriptor, Result}
+import org.anon.spareuse.execution.analyses.{AnalysisImplementation, AnalysisImplementationDescriptor, AnalysisResult, FreshResult}
 
 import scala.collection.mutable
 import scala.util.Try
@@ -25,7 +25,7 @@ class MvnConstantClassAnalysisImpl extends AnalysisImplementation {
     }
   }
 
-  override def executeAnalysis(inputs: Seq[SoftwareEntityData], rawConfig: String): Try[Set[Result]] = Try {
+  override def executeAnalysis(inputs: Seq[SoftwareEntityData], rawConfig: String): Try[Set[AnalysisResult]] = Try {
 
     if(!rawConfig.isBlank)
       log.warn("Non-Empty configuration will be ignored, this analysis does not support configuration options")
@@ -57,7 +57,7 @@ class MvnConstantClassAnalysisImpl extends AnalysisImplementation {
       classToHashesMap.mapValues(b => (b.size, b.distinct.size)).foreach{t => log.debug(s"-- ${t._1} -> ${t._2._2}/${t._2._1}")}
 
 
-      Result(resultMap, Set(library))
+      FreshResult(resultMap, Set(library))
     }.toSet
   }
 

--- a/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/impl/MvnDependencyAnalysisImpl.scala
+++ b/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/impl/MvnDependencyAnalysisImpl.scala
@@ -26,10 +26,17 @@ class MvnDependencyAnalysisImpl extends AnalysisImplementation{
   )
 
 
-  override val analysisData: AnalysisData = AnalysisData("mvn-dependencies", "1.0.0", "TBD", "built-in", "system",
-    Set("java"), isRevoked = false, resultFormat, SoftwareEntityKind.Program, Set.empty)
-
-  override val inputBatchProcessing: Boolean = true
+  override val analysisData: AnalysisData = AnalysisData.systemAnalysis(
+    "mvn-dependencies",
+    "1.0.0",
+    "TBD",
+    "Scala, built-in facilities",
+    Set("java"),
+    resultFormat,
+    SoftwareEntityKind.Program,
+    doesBatchProcessing = true,
+    isIncremental = false
+  )
 
   // This analysis does not need any DB information
   override val requiredInputResolutionLevel: SoftwareEntityKind = SoftwareEntityKind.Program

--- a/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/impl/MvnDependencyAnalysisImpl.scala
+++ b/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/impl/MvnDependencyAnalysisImpl.scala
@@ -8,7 +8,7 @@ import org.anon.spareuse.core.model.{AnalysisData, SoftwareEntityKind}
 import org.anon.spareuse.core.model.SoftwareEntityKind.SoftwareEntityKind
 import org.anon.spareuse.core.model.entities.JavaEntities.JavaProgram
 import org.anon.spareuse.core.model.entities.SoftwareEntityData
-import org.anon.spareuse.execution.analyses.{AnalysisImplementation, AnalysisImplementationDescriptor, Result}
+import org.anon.spareuse.execution.analyses.{AnalysisImplementation, AnalysisImplementationDescriptor, AnalysisResult, FreshResult}
 
 import scala.util.{Failure, Success, Try}
 
@@ -29,7 +29,7 @@ class MvnDependencyAnalysisImpl extends AnalysisImplementation{
     }
   }
 
-  override def executeAnalysis(inputs: Seq[SoftwareEntityData], configRaw: String): Try[Set[Result]] = Try {
+  override def executeAnalysis(inputs: Seq[SoftwareEntityData], configRaw: String): Try[Set[AnalysisResult]] = Try {
     val theConfig = parseConfig(configRaw)
     val resolver: DependencyExtractor = if(theConfig.useJeka) new JekaDependencyExtractor() else new PomFileDependencyExtractor()
 
@@ -52,7 +52,7 @@ class MvnDependencyAnalysisImpl extends AnalysisImplementation{
             log.debug(s"Results for program [$gav]:")
             dependencies.foreach{ d => log.debug(s"-- ${d.identifier}:${d.scope}")}
 
-            Result(dependencies, Set(jp))
+            FreshResult(dependencies, Set(jp))
           case Failure(ex) =>
             log.error("Dependency extraction failed", ex)
             throw ex

--- a/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/impl/MvnDependencyAnalysisImpl.scala
+++ b/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/impl/MvnDependencyAnalysisImpl.scala
@@ -8,46 +8,21 @@ import org.anon.spareuse.core.model.{AnalysisData, SoftwareEntityKind}
 import org.anon.spareuse.core.model.SoftwareEntityKind.SoftwareEntityKind
 import org.anon.spareuse.core.model.entities.JavaEntities.JavaProgram
 import org.anon.spareuse.core.model.entities.SoftwareEntityData
-import org.anon.spareuse.execution.analyses.{AnalysisImplementation, Result}
+import org.anon.spareuse.execution.analyses.{AnalysisImplementation, AnalysisImplementationDescriptor, Result}
 
 import scala.util.{Failure, Success, Try}
 
 class MvnDependencyAnalysisImpl extends AnalysisImplementation{
 
-  private val resultFormat = ListResultFormat(
-    ObjectResultFormat(Set(
-      NamedPropertyFormat("identifier", ObjectResultFormat(Set(
-        NamedPropertyFormat("groupId", formats.StringFormat),
-        NamedPropertyFormat("artifactId", formats.StringFormat),
-        NamedPropertyFormat("version", formats.StringFormat)
-      )), "The GAV-Triple identifying a dependency, i.e. a required Maven library."),
-      NamedPropertyFormat("scope", formats.StringFormat, "The Maven scope of this dependency")
-    )), "Dependencies (GAV-Triple) for this program"
-  )
-
-
-  override val analysisData: AnalysisData = AnalysisData.systemAnalysis(
-    "mvn-dependencies",
-    "1.0.0",
-    "TBD",
-    "Scala, built-in facilities",
-    Set("java"),
-    resultFormat,
-    SoftwareEntityKind.Program,
-    doesBatchProcessing = true,
-    isIncremental = false
-  )
-
-  // This analysis does not need any DB information
-  override val requiredInputResolutionLevel: SoftwareEntityKind = SoftwareEntityKind.Program
+  override val descriptor: AnalysisImplementationDescriptor = MvnDependencyAnalysisImpl
 
   override def executionPossible(inputs: Seq[SoftwareEntityData], configRaw: String): Boolean = {
 
     if(inputs.exists( e => !e.isInstanceOf[JavaProgram])){
-      log.warn(s"Execution of analysis $name:$version not possible: Inputs must be of kind 'Program'")
+      log.warn(s"Execution of analysis ${descriptor.fullName} not possible: Inputs must be of kind 'Program'")
       false
     } else if(!isValidConfig(configRaw)){
-      log.warn(s"Execution of analysis $name:$version not possible: Configuration not valid: $configRaw")
+      log.warn(s"Execution of analysis ${descriptor.fullName} not possible: Configuration not valid: $configRaw")
       false
     } else {
       true
@@ -111,6 +86,34 @@ class MvnDependencyAnalysisImpl extends AnalysisImplementation{
   }
 
   private case class DependencyAnalysisConfig(useJeka: Boolean, enableTransitive: Boolean)
+}
 
+object MvnDependencyAnalysisImpl extends AnalysisImplementationDescriptor {
+
+  private val resultFormat = ListResultFormat(
+    ObjectResultFormat(Set(
+      NamedPropertyFormat("identifier", ObjectResultFormat(Set(
+        NamedPropertyFormat("groupId", formats.StringFormat),
+        NamedPropertyFormat("artifactId", formats.StringFormat),
+        NamedPropertyFormat("version", formats.StringFormat)
+      )), "The GAV-Triple identifying a dependency, i.e. a required Maven library."),
+      NamedPropertyFormat("scope", formats.StringFormat, "The Maven scope of this dependency")
+    )), "Dependencies (GAV-Triple) for this program"
+  )
+
+  override val analysisData: AnalysisData = AnalysisData.systemAnalysis(
+    "mvn-dependencies",
+    "1.0.0",
+    "TBD",
+    "Scala, built-in facilities",
+    Set("java"),
+    resultFormat,
+    SoftwareEntityKind.Program,
+    doesBatchProcessing = true,
+    isIncremental = false
+  )
+
+  // This analysis does not need any DB information
+  override val requiredInputResolutionLevel: SoftwareEntityKind = SoftwareEntityKind.Program
 
 }

--- a/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/impl/MvnPartialCallgraphAnalysisImpl.scala
+++ b/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/impl/MvnPartialCallgraphAnalysisImpl.scala
@@ -10,7 +10,7 @@ import org.anon.spareuse.core.model.entities.SoftwareEntityData
 import org.anon.spareuse.core.opal.OPALProjectHelper
 import org.anon.spareuse.core.utils.http.HttpDownloadException
 import MvnPartialCallgraphAnalysisImpl.{InternalCallSite, InternalMethod, RTAResult, TypeNode, parseConfig, validCallgraphAlgorithms}
-import org.anon.spareuse.execution.analyses.{AnalysisImplementation, Result}
+import org.anon.spareuse.execution.analyses.{AnalysisImplementation, AnalysisImplementationDescriptor, Result}
 import org.opalj.br.instructions.Instruction
 import org.opalj.br.{DeclaredMethod, Method, ObjectType}
 import org.opalj.tac.cg.{CHACallGraphKey, CTACallGraphKey, RTACallGraphKey, XTACallGraphKey}
@@ -21,61 +21,7 @@ import scala.util.{Failure, Success, Try}
 
 class MvnPartialCallgraphAnalysisImpl extends AnalysisImplementation {
 
-  private val resultFormat: AnalysisResultFormat = ObjectResultFormat(
-    NamedPropertyFormat("graph",
-      ListResultFormat(
-        ObjectResultFormat(Set(
-          NamedPropertyFormat("mId", formats.NumberFormat, "The unique id assigned to this method"),
-          NamedPropertyFormat("mFqn", formats.StringFormat, "The fully qualified name of this method"),
-          NamedPropertyFormat("reachable", formats.NumberFormat, "Indicates whether this method was reachable in the partial callgraph"),
-          NamedPropertyFormat("css", ListResultFormat(ObjectResultFormat(Set(
-            NamedPropertyFormat("csPc", formats.NumberFormat, "PC of this callsite inside the enclosing method body"),
-            NamedPropertyFormat("targets", ListResultFormat(formats.NumberFormat), "List of method ids that have been resolved as targets for this callsite"),
-            NamedPropertyFormat("incomplete", formats.NumberFormat, "Indicates whether the resolution of this callsite was incomplete"),
-            NamedPropertyFormat("instr", formats.StringFormat, "String representation of the callsite instruction")
-          )), "List of callsites for this method"))
-        ))
-        , "List of Method definitions with callsite information")
-      , "The actual RTA callgraph"),
-    NamedPropertyFormat("types",
-      ListResultFormat(ObjectResultFormat(
-        NamedPropertyFormat("id", formats.NumberFormat, "The unique id for this type"),
-        NamedPropertyFormat("fqn", formats.StringFormat, "The type FQN"),
-        NamedPropertyFormat("interface", formats.NumberFormat, "Number indicating whether this type is an interface definition"),
-        NamedPropertyFormat("superId", formats.NumberFormat, "The id of the super type, or -1 if there is none"),
-        NamedPropertyFormat("interfaceIds", formats.ListResultFormat(formats.NumberFormat), "The set of interface type ids")
-      ))
-      , "A list of type nodes")
-  )
-
-  private val resultFormat2: AnalysisResultFormat = ListResultFormat(
-    ObjectResultFormat(Set(
-      NamedPropertyFormat("mId", formats.NumberFormat, "The unique id assigned to this method"),
-      NamedPropertyFormat("mFqn", formats.StringFormat, "The fully qualified name of this method"),
-      NamedPropertyFormat("reachable", formats.NumberFormat, "Indicates whether this method was reachable in the partial callgraph"),
-      NamedPropertyFormat("css", ListResultFormat(ObjectResultFormat(Set(
-        NamedPropertyFormat("csPc", formats.NumberFormat, "PC of this callsite inside the enclosing method body"),
-        NamedPropertyFormat("targets", ListResultFormat(formats.NumberFormat), "List of method ids that have been resolved as targets for this callsite"),
-        NamedPropertyFormat("incomplete", formats.NumberFormat, "Indicates whether the resolution of this callsite was incomplete"),
-        NamedPropertyFormat("instr", formats.StringFormat, "String representation of the callsite instruction")
-      )), "List of callsites for this method"))
-    ))
-  , "List of Method definitions with callsite information")
-
-  override val analysisData: AnalysisData = AnalysisData.systemAnalysis(
-    "mvn-partial-callgraphs",
-    "1.0.0",
-    "This analysis uses OPAL to calculate a partial callgraph for a given Maven program (GAV-Triple). The graph is returned as a list of methods with unique ids and references to callees. " +
-      "Multiple construction algorithms are supported (use '--algorithm cha|rta|xta|cta'), default is RTA. Use '--use-jre' to include JRE implementations in callgraph.",
-    "OPAL",
-    Set("java", "scala"),
-    resultFormat,
-    SoftwareEntityKind.Program,
-    doesBatchProcessing = true,
-    isIncremental = false)
-
-
-  override val requiredInputResolutionLevel: SoftwareEntityKind = SoftwareEntityKind.Package
+  override val descriptor: AnalysisImplementationDescriptor = MvnPartialCallgraphAnalysisImpl
 
   override def executionPossible(inputs: Seq[SoftwareEntityData], rawConfig: String): Boolean = {
 
@@ -239,9 +185,65 @@ class MvnPartialCallgraphAnalysisImpl extends AnalysisImplementation {
   }
 }
 
-object MvnPartialCallgraphAnalysisImpl {
+object MvnPartialCallgraphAnalysisImpl extends AnalysisImplementationDescriptor {
 
   val validCallgraphAlgorithms: Set[String] = Set("cha", "rta", "cta", "xta")
+
+  private val resultFormat: AnalysisResultFormat = ObjectResultFormat(
+    NamedPropertyFormat("graph",
+      ListResultFormat(
+        ObjectResultFormat(Set(
+          NamedPropertyFormat("mId", formats.NumberFormat, "The unique id assigned to this method"),
+          NamedPropertyFormat("mFqn", formats.StringFormat, "The fully qualified name of this method"),
+          NamedPropertyFormat("reachable", formats.NumberFormat, "Indicates whether this method was reachable in the partial callgraph"),
+          NamedPropertyFormat("css", ListResultFormat(ObjectResultFormat(Set(
+            NamedPropertyFormat("csPc", formats.NumberFormat, "PC of this callsite inside the enclosing method body"),
+            NamedPropertyFormat("targets", ListResultFormat(formats.NumberFormat), "List of method ids that have been resolved as targets for this callsite"),
+            NamedPropertyFormat("incomplete", formats.NumberFormat, "Indicates whether the resolution of this callsite was incomplete"),
+            NamedPropertyFormat("instr", formats.StringFormat, "String representation of the callsite instruction")
+          )), "List of callsites for this method"))
+        ))
+        , "List of Method definitions with callsite information")
+      , "The actual RTA callgraph"),
+    NamedPropertyFormat("types",
+      ListResultFormat(ObjectResultFormat(
+        NamedPropertyFormat("id", formats.NumberFormat, "The unique id for this type"),
+        NamedPropertyFormat("fqn", formats.StringFormat, "The type FQN"),
+        NamedPropertyFormat("interface", formats.NumberFormat, "Number indicating whether this type is an interface definition"),
+        NamedPropertyFormat("superId", formats.NumberFormat, "The id of the super type, or -1 if there is none"),
+        NamedPropertyFormat("interfaceIds", formats.ListResultFormat(formats.NumberFormat), "The set of interface type ids")
+      ))
+      , "A list of type nodes")
+  )
+
+  private val resultFormat2: AnalysisResultFormat = ListResultFormat(
+    ObjectResultFormat(Set(
+      NamedPropertyFormat("mId", formats.NumberFormat, "The unique id assigned to this method"),
+      NamedPropertyFormat("mFqn", formats.StringFormat, "The fully qualified name of this method"),
+      NamedPropertyFormat("reachable", formats.NumberFormat, "Indicates whether this method was reachable in the partial callgraph"),
+      NamedPropertyFormat("css", ListResultFormat(ObjectResultFormat(Set(
+        NamedPropertyFormat("csPc", formats.NumberFormat, "PC of this callsite inside the enclosing method body"),
+        NamedPropertyFormat("targets", ListResultFormat(formats.NumberFormat), "List of method ids that have been resolved as targets for this callsite"),
+        NamedPropertyFormat("incomplete", formats.NumberFormat, "Indicates whether the resolution of this callsite was incomplete"),
+        NamedPropertyFormat("instr", formats.StringFormat, "String representation of the callsite instruction")
+      )), "List of callsites for this method"))
+    ))
+    , "List of Method definitions with callsite information")
+
+  override val analysisData: AnalysisData = AnalysisData.systemAnalysis(
+    "mvn-partial-callgraphs",
+    "1.0.0",
+    "This analysis uses OPAL to calculate a partial callgraph for a given Maven program (GAV-Triple). The graph is returned as a list of methods with unique ids and references to callees. " +
+      "Multiple construction algorithms are supported (use '--algorithm cha|rta|xta|cta'), default is RTA. Use '--use-jre' to include JRE implementations in callgraph.",
+    "OPAL",
+    Set("java", "scala"),
+    resultFormat,
+    SoftwareEntityKind.Program,
+    doesBatchProcessing = true,
+    isIncremental = false)
+
+
+  override val requiredInputResolutionLevel: SoftwareEntityKind = SoftwareEntityKind.Package
 
   case class PartialCallgraphAnalysisConfig(algorithm: String, includeJre: Boolean, applicationMode: Boolean)
 

--- a/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/impl/MvnPartialCallgraphAnalysisImpl.scala
+++ b/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/impl/MvnPartialCallgraphAnalysisImpl.scala
@@ -1,7 +1,7 @@
 package org.anon.spareuse.execution.analyses.impl
 
 import org.anon.spareuse.core.formats
-import org.anon.spareuse.core.formats.{AnalysisResultFormat, ListResultFormat, NamedPropertyFormat, NumberFormat, ObjectResultFormat}
+import org.anon.spareuse.core.formats.{AnalysisResultFormat, ListResultFormat, NamedPropertyFormat, ObjectResultFormat}
 import org.anon.spareuse.core.maven.MavenIdentifier
 import org.anon.spareuse.core.model.SoftwareEntityKind.SoftwareEntityKind
 import org.anon.spareuse.core.model.entities.JavaEntities.JavaProgram
@@ -10,7 +10,7 @@ import org.anon.spareuse.core.model.entities.SoftwareEntityData
 import org.anon.spareuse.core.opal.OPALProjectHelper
 import org.anon.spareuse.core.utils.http.HttpDownloadException
 import MvnPartialCallgraphAnalysisImpl.{InternalCallSite, InternalMethod, RTAResult, TypeNode, parseConfig, validCallgraphAlgorithms}
-import org.anon.spareuse.execution.analyses.{AnalysisImplementation, AnalysisImplementationDescriptor, Result}
+import org.anon.spareuse.execution.analyses.{AnalysisImplementation, AnalysisImplementationDescriptor, AnalysisResult, FreshResult}
 import org.opalj.br.instructions.Instruction
 import org.opalj.br.{DeclaredMethod, Method, ObjectType}
 import org.opalj.tac.cg.{CHACallGraphKey, CTACallGraphKey, RTACallGraphKey, XTACallGraphKey}
@@ -43,7 +43,7 @@ class MvnPartialCallgraphAnalysisImpl extends AnalysisImplementation {
     inputs.forall( sed => sed.isInstanceOf[JavaProgram])
   }
 
-  override def executeAnalysis(inputs: Seq[SoftwareEntityData], rawConfig: String): Try[Set[Result]] = Try {
+  override def executeAnalysis(inputs: Seq[SoftwareEntityData], rawConfig: String): Try[Set[AnalysisResult]] = Try {
 
     val opalHelper = new OPALProjectHelper(loadJreClassImplementation = false)
     val config = parseConfig(rawConfig)
@@ -170,7 +170,7 @@ class MvnPartialCallgraphAnalysisImpl extends AnalysisImplementation {
 
           log.info(s"Done building partial callgraph representation for ${program.name}")
 
-          Some(Result(resultContent, Set(program)))
+          Some(FreshResult(resultContent, Set(program)))
 
         case Failure(HttpDownloadException(status, _, _)) if status == 404 =>
           log.warn(s"No JAR file available for ${program.identifier}")

--- a/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/impl/MvnPartialCallgraphAnalysisImpl.scala
+++ b/analysis-runner/src/main/scala/org/anon/spareuse/execution/analyses/impl/MvnPartialCallgraphAnalysisImpl.scala
@@ -69,10 +69,11 @@ class MvnPartialCallgraphAnalysisImpl extends AnalysisImplementation {
       "Multiple construction algorithms are supported (use '--algorithm cha|rta|xta|cta'), default is RTA. Use '--use-jre' to include JRE implementations in callgraph.",
     "OPAL",
     Set("java", "scala"),
-    resultFormat, SoftwareEntityKind.Program)
+    resultFormat,
+    SoftwareEntityKind.Program,
+    doesBatchProcessing = true,
+    isIncremental = false)
 
-
-  override val inputBatchProcessing: Boolean = true
 
   override val requiredInputResolutionLevel: SoftwareEntityKind = SoftwareEntityKind.Package
 

--- a/analysis-runner/src/test/scala/org/anon/spareuse/execution/analyses/IncrementalAnalysisImplementationTest.scala
+++ b/analysis-runner/src/test/scala/org/anon/spareuse/execution/analyses/IncrementalAnalysisImplementationTest.scala
@@ -2,9 +2,10 @@ package org.anon.spareuse.execution.analyses
 
 import org.anon.spareuse.core.formats.{EmptyFormat, ListResultFormat}
 import org.anon.spareuse.core.model.SoftwareEntityKind.SoftwareEntityKind
+import org.anon.spareuse.core.model.entities.JavaEntities.{JavaClass, JavaMethod}
 import org.anon.spareuse.core.model.{AnalysisData, AnalysisResultData, AnalysisRunData, SoftwareEntityKind}
 import org.anon.spareuse.core.model.entities.SoftwareEntityData
-import org.anon.spareuse.core.testutils.SoftwareEntityTestDataFactory
+import org.anon.spareuse.core.testutils.{AnalysisTestDataFactory, SoftwareEntityTestDataFactory}
 import org.scalatest.funspec.AnyFunSpec
 
 import scala.util.{Success, Try}
@@ -41,7 +42,44 @@ class IncrementalAnalysisImplementationTest extends AnyFunSpec {
       assert(result.isSuccess && result.get.isEmpty)
     }
 
-    //TODO: More elaborate tests on how analysis steps are being scheduled
+    it("should execute the analysis three times if baselines exist for all three inputs"){
+      val dummyAnalysisDescriptor = buildDummyDescriptor(SoftwareEntityKind.Method, batch = true)
+
+      val baselineM1 = SoftwareEntityTestDataFactory.fullMethodEntity("a.b:c:1.0.0", "my.package", "MyClass", "doFoo")
+      val baselineM2 = SoftwareEntityTestDataFactory.methodFor(baselineM1.getParent.get.asInstanceOf[JavaClass], "doBar")
+      val baselineM3 = SoftwareEntityTestDataFactory.methodFor(baselineM1.getParent.get.asInstanceOf[JavaClass], "doNothing", returnType = "Void")
+      val baselineEntities = Set(baselineM1, baselineM2, baselineM3)
+
+      val currentM1 = SoftwareEntityTestDataFactory.fullMethodEntity("a.b:c:3.0.0", "my.package", "MyClass", "doFoo")
+      val currentM2 = SoftwareEntityTestDataFactory.methodFor(currentM1.getParent.get.asInstanceOf[JavaClass], "doBar")
+      val currentM3 = SoftwareEntityTestDataFactory.methodFor(currentM1.getParent.get.asInstanceOf[JavaClass], "doNothing", returnType = "Void")
+      val currentEntities = Set(currentM1, currentM2, currentM3)
+
+      val baselineResults = baselineEntities.map{ e => AnalysisTestDataFactory.stringResult(e.name, Set(e), uid = s"DUMMY-RESULT-${e.name}")}
+      val baselineRun = AnalysisTestDataFactory.analysisRun(dummyAnalysisDescriptor.name, dummyAnalysisDescriptor.version, baselineResults, baselineEntities.map(_.asInstanceOf[SoftwareEntityData]))
+
+      var executionStepCnt = 0
+
+      val dummyImpl = buildDummyImpl(dummyAnalysisDescriptor, Some(baselineRun)){ (inputs, prevResult) =>
+
+        assert(inputs.size == 1)
+        assert(inputs.head.isMethod)
+        assert(prevResult.isDefined)
+
+        val resContent = prevResult.get.content.asInstanceOf[String]
+        val currentInputName = inputs.head.asInstanceOf[JavaMethod].name
+
+        assert(resContent.equals(currentInputName))
+
+        executionStepCnt += 1
+        Success(Set.empty)
+      }
+
+      val result = dummyImpl.executeAnalysis(currentEntities.toSeq.map(_.asInstanceOf[SoftwareEntityData]), "")
+
+      assert(executionStepCnt == 3)
+
+    }
 
   }
 

--- a/analysis-runner/src/test/scala/org/anon/spareuse/execution/analyses/IncrementalAnalysisImplementationTest.scala
+++ b/analysis-runner/src/test/scala/org/anon/spareuse/execution/analyses/IncrementalAnalysisImplementationTest.scala
@@ -1,0 +1,66 @@
+package org.anon.spareuse.execution.analyses
+
+import org.anon.spareuse.core.formats.{EmptyFormat, ListResultFormat}
+import org.anon.spareuse.core.model.SoftwareEntityKind.SoftwareEntityKind
+import org.anon.spareuse.core.model.{AnalysisData, AnalysisResultData, AnalysisRunData, SoftwareEntityKind}
+import org.anon.spareuse.core.model.entities.SoftwareEntityData
+import org.anon.spareuse.testutils.SoftwareEntityTestDataFactory
+import org.scalatest.funspec.AnyFunSpec
+
+import scala.util.{Success, Try}
+
+class IncrementalAnalysisImplementationTest extends AnyFunSpec {
+
+  type IncrementalAnalysisStep = (Seq[SoftwareEntityData], Option[AnalysisResultData]) => Try[Set[Result]]
+
+  describe("Any incremental analysis implementation"){
+
+    it("should not execute the analysis for no inputs"){
+      val dummyImpl = buildDummyImpl(buildDummyDescriptor(SoftwareEntityKind.Method, batch = true), None){ (inputs, prevResult) =>
+        fail("Analysis step should not be executed for no inputs")
+      }
+
+      dummyImpl.executeAnalysis(Seq.empty, "")
+    }
+
+    it("should execute the analysis once for all inputs if no baseline is specified"){
+
+      var executionStepCnt = 0
+      val dummyInputs: Seq[SoftwareEntityData] = for( i <- Range(0, 3)) yield SoftwareEntityTestDataFactory.genericEntity(name = s"group:artifact:$i")
+
+      val dummyImpl = buildDummyImpl(buildDummyDescriptor(SoftwareEntityKind.Method, batch = true), None){ (inputs, prevResult) =>
+        executionStepCnt += 1
+        assert(prevResult.isEmpty)
+        assert(inputs.size == dummyInputs.size)
+        Success(Set.empty)
+      }
+
+      val result = dummyImpl.executeAnalysis(dummyInputs, "")
+
+      assert(executionStepCnt == 1)
+      assert(result.isSuccess && result.get.isEmpty)
+    }
+
+    //TODO: More elaborate tests on how analysis steps are being scheduled
+
+  }
+
+  private def buildDummyDescriptor(inputKind: SoftwareEntityKind, batch: Boolean): AnalysisImplementationDescriptor = new AnalysisImplementationDescriptor {
+    override val analysisData: AnalysisData = new AnalysisData("demo-incremental-analysis", "1.0.0", "",
+      "", "system", Set.empty, false, ListResultFormat(EmptyFormat), inputKind, batch, true, Set.empty)
+  }
+
+  private def buildDummyImpl(d: AnalysisImplementationDescriptor,
+                             baseline: Option[AnalysisRunData])
+                            (implicit impl: IncrementalAnalysisStep): IncrementalAnalysisImplementation = new IncrementalAnalysisImplementation(baseline) {
+
+    override def executeIncremental(inputs: Seq[SoftwareEntityData],
+                                    previousResult: Option[AnalysisResultData]): Try[Set[Result]] = impl(inputs, previousResult)
+
+    override val descriptor: AnalysisImplementationDescriptor = d
+
+    override def executionPossible(inputs: Seq[SoftwareEntityData], rawConfig: String): Boolean = true
+  }
+
+
+}

--- a/analysis-runner/src/test/scala/org/anon/spareuse/execution/analyses/IncrementalAnalysisImplementationTest.scala
+++ b/analysis-runner/src/test/scala/org/anon/spareuse/execution/analyses/IncrementalAnalysisImplementationTest.scala
@@ -11,7 +11,7 @@ import scala.util.{Success, Try}
 
 class IncrementalAnalysisImplementationTest extends AnyFunSpec {
 
-  type IncrementalAnalysisStep = (Seq[SoftwareEntityData], Option[AnalysisResultData]) => Try[Set[Result]]
+  type IncrementalAnalysisStep = (Seq[SoftwareEntityData], Option[AnalysisResultData]) => Try[Set[AnalysisResult]]
 
   describe("Any incremental analysis implementation"){
 
@@ -55,7 +55,7 @@ class IncrementalAnalysisImplementationTest extends AnyFunSpec {
                             (implicit impl: IncrementalAnalysisStep): IncrementalAnalysisImplementation = new IncrementalAnalysisImplementation(baseline) {
 
     override def executeIncremental(inputs: Seq[SoftwareEntityData],
-                                    previousResult: Option[AnalysisResultData]): Try[Set[Result]] = impl(inputs, previousResult)
+                                    previousResult: Option[AnalysisResultData]): Try[Set[AnalysisResult]] = impl(inputs, previousResult)
 
     override val descriptor: AnalysisImplementationDescriptor = d
 

--- a/analysis-runner/src/test/scala/org/anon/spareuse/execution/analyses/IncrementalAnalysisImplementationTest.scala
+++ b/analysis-runner/src/test/scala/org/anon/spareuse/execution/analyses/IncrementalAnalysisImplementationTest.scala
@@ -4,7 +4,7 @@ import org.anon.spareuse.core.formats.{EmptyFormat, ListResultFormat}
 import org.anon.spareuse.core.model.SoftwareEntityKind.SoftwareEntityKind
 import org.anon.spareuse.core.model.{AnalysisData, AnalysisResultData, AnalysisRunData, SoftwareEntityKind}
 import org.anon.spareuse.core.model.entities.SoftwareEntityData
-import org.anon.spareuse.testutils.SoftwareEntityTestDataFactory
+import org.anon.spareuse.core.testutils.SoftwareEntityTestDataFactory
 import org.scalatest.funspec.AnyFunSpec
 
 import scala.util.{Success, Try}

--- a/analysis-runner/src/test/scala/org/anon/spareuse/execution/analyses/impl/MvnConstantClassAnalysisImplTest.scala
+++ b/analysis-runner/src/test/scala/org/anon/spareuse/execution/analyses/impl/MvnConstantClassAnalysisImplTest.scala
@@ -4,6 +4,7 @@ import org.anon.spareuse.core.formats
 import org.anon.spareuse.core.formats.json.CustomObjectWriter
 import org.anon.spareuse.core.formats.{MapResultFormat, NamedPropertyFormat, NumberFormat, ObjectResultFormat}
 import org.anon.spareuse.core.model.entities.JavaEntities.{buildClassFor, buildLibrary, buildPackageFor, buildProgramFor}
+import org.anon.spareuse.execution.analyses.FreshResult
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must
 
@@ -65,7 +66,9 @@ class MvnConstantClassAnalysisImplTest extends AnyFlatSpec with must.Matchers {
 
     assert(result.isSuccess && result.get.size == 1)
 
-    val data = result.get.head
+    assert(result.get.head.isFresh)
+
+    val data = result.get.head.asInstanceOf[FreshResult]
 
     assert(data.affectedEntities.contains(lib) && data.affectedEntities.size == 1)
 

--- a/analysis-runner/src/test/scala/org/anon/spareuse/execution/analyses/impl/MvnDependencyAnalysisImplTest.scala
+++ b/analysis-runner/src/test/scala/org/anon/spareuse/execution/analyses/impl/MvnDependencyAnalysisImplTest.scala
@@ -4,6 +4,7 @@ import org.anon.spareuse.core.formats
 import org.anon.spareuse.core.formats.json.CustomObjectWriter
 import org.anon.spareuse.core.formats.{ListResultFormat, MapResultFormat, NamedPropertyFormat, ObjectResultFormat}
 import org.anon.spareuse.core.model.entities.JavaEntities.{JavaProgram, buildPackage, buildPackageFor}
+import org.anon.spareuse.execution.analyses.FreshResult
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must
 
@@ -27,10 +28,15 @@ class MvnDependencyAnalysisImplTest extends AnyFlatSpec with must.Matchers {
 
     assert(result.isSuccess)
     assert(result.get.size == 1)
-    assert(result.get.head.affectedEntities.size == 1 && result.get.head.affectedEntities.head.equals(sampleProgram))
+    assert(result.get.head.isFresh)
+
+    val data = result.get.head.asInstanceOf[FreshResult]
+
+
+    assert(data.affectedEntities.size == 1 && data.affectedEntities.head.equals(sampleProgram))
 
     val writer = new CustomObjectWriter(expectedResultFormat)
-    val json = writer.write(result.get.head.content)
+    val json = writer.write(data.content)
 
     println(json.prettyPrint)
 

--- a/analysis-runner/src/test/scala/org/anon/spareuse/execution/commands/RunnerCommandTest.scala
+++ b/analysis-runner/src/test/scala/org/anon/spareuse/execution/commands/RunnerCommandTest.scala
@@ -1,6 +1,6 @@
 package org.anon.spareuse.execution.commands
 
-import org.anon.spareuse.core.model.analysis.{RunnerCommand, RunnerCommandJsonSupport}
+import org.anon.spareuse.core.model.analysis.{AnalysisCommand, IncrementalAnalysisCommand, RunnerCommand, RunnerCommandJsonSupport}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must
 import spray.json._
@@ -8,7 +8,7 @@ import spray.json._
 class RunnerCommandTest extends AnyFlatSpec with must.Matchers with RunnerCommandJsonSupport{
 
   "The runner command serialization" must "perform a valid roundtrip serialization" in {
-    val startCmd = RunnerCommand("dep-analysis", "some-id", "my-user", Set("test", "entity"), "some-config=")
+    val startCmd = AnalysisCommand("dep-analysis", "some-id", "my-user", Set("test", "entity"), "some-config=")
 
     val json = startCmd.toJson.compactPrint
 
@@ -16,6 +16,20 @@ class RunnerCommandTest extends AnyFlatSpec with must.Matchers with RunnerComman
 
     val cmd = json.parseJson.convertTo[RunnerCommand]
 
+    assert(cmd.isInstanceOf[AnalysisCommand])
+    assert(cmd.equals(startCmd))
+  }
+
+  "The runner command serialization" must "correctly deserialize an IncrementalAnalysisCommand" in {
+    val startCmd = IncrementalAnalysisCommand("dep-analysis", "some-id", "my-user", Set("test", "entity"), "some-config=", "some-other-id")
+
+    val json = startCmd.toJson.compactPrint
+
+    println(json)
+
+    val cmd = json.parseJson.convertTo[RunnerCommand]
+
+    assert(cmd.isInstanceOf[IncrementalAnalysisCommand])
     assert(cmd.equals(startCmd))
   }
 

--- a/core/src/main/scala/org/anon/spareuse/core/model/AnalysisData.scala
+++ b/core/src/main/scala/org/anon/spareuse/core/model/AnalysisData.scala
@@ -9,12 +9,12 @@ import java.time.LocalDateTime
 
 case class AnalysisData(name: String, version: String, description: String, builtOn: String, registeredBy: String,
                         inputLanguages: Set[String], isRevoked: Boolean, resultFormat: AnalysisResultFormat, inputKind: SoftwareEntityKind,
-                        executions: Set[AnalysisRunData])
+                        doesBatchProcessing: Boolean, isIncremental: Boolean, executions: Set[AnalysisRunData])
 
 object AnalysisData {
   def systemAnalysis(name: String, version: String, description: String, builtOn: String, languages: Set[String],
-                     format: AnalysisResultFormat, inputKind: SoftwareEntityKind): AnalysisData = {
-    AnalysisData(name, version, description, builtOn, "system", languages, isRevoked = false, format, inputKind, Set.empty)
+                     format: AnalysisResultFormat, inputKind: SoftwareEntityKind, doesBatchProcessing: Boolean, isIncremental: Boolean): AnalysisData = {
+    AnalysisData(name, version, description, builtOn, "system", languages, isRevoked = false, format, inputKind, doesBatchProcessing, isIncremental, Set.empty)
   }
 }
 

--- a/core/src/main/scala/org/anon/spareuse/core/model/AnalysisResultData.scala
+++ b/core/src/main/scala/org/anon/spareuse/core/model/AnalysisResultData.scala
@@ -2,7 +2,7 @@ package org.anon.spareuse.core.model
 
 import org.anon.spareuse.core.model.entities.{GenericEntityData, SoftwareEntityData}
 
-case class AnalysisResultData(uid: String, isRevoked: Boolean, content: Object, affectedEntities: Set[SoftwareEntityData]){
+case class AnalysisResultData(uid: String, isRevoked: Boolean, originRunUid: String, content: Object, affectedEntities: Set[SoftwareEntityData]){
 
   def withResolvedGenerics(resolver: String => SoftwareEntityData, forceResolve: Boolean = false): AnalysisResultData = {
 
@@ -15,7 +15,7 @@ case class AnalysisResultData(uid: String, isRevoked: Boolean, content: Object, 
         s
     }
 
-    AnalysisResultData(uid, isRevoked, content, affectedEntities.map(resolveIfNeeded))
+    AnalysisResultData(uid, isRevoked, originRunUid, content, affectedEntities.map(resolveIfNeeded))
   }
 
 }

--- a/core/src/main/scala/org/anon/spareuse/core/model/AnalysisResultData.scala
+++ b/core/src/main/scala/org/anon/spareuse/core/model/AnalysisResultData.scala
@@ -1,5 +1,21 @@
 package org.anon.spareuse.core.model
 
-import org.anon.spareuse.core.model.entities.SoftwareEntityData
+import org.anon.spareuse.core.model.entities.{GenericEntityData, SoftwareEntityData}
 
-case class AnalysisResultData(uid: String, isRevoked: Boolean, content: Object, affectedEntities: Set[SoftwareEntityData])
+case class AnalysisResultData(uid: String, isRevoked: Boolean, content: Object, affectedEntities: Set[SoftwareEntityData]){
+
+  def withResolvedGenerics(resolver: String => SoftwareEntityData, forceResolve: Boolean = false): AnalysisResultData = {
+
+    def resolveIfNeeded(sed: SoftwareEntityData) = sed match {
+      case g: GenericEntityData =>
+        resolver(g.uid)
+      case s: SoftwareEntityData if (!s.hasParent && s.getChildren.isEmpty) || forceResolve =>
+        resolver(s.uid)
+      case s@_ =>
+        s
+    }
+
+    AnalysisResultData(uid, isRevoked, content, affectedEntities.map(resolveIfNeeded))
+  }
+
+}

--- a/core/src/main/scala/org/anon/spareuse/core/model/analysis/RunnerCommand.scala
+++ b/core/src/main/scala/org/anon/spareuse/core/model/analysis/RunnerCommand.scala
@@ -2,13 +2,69 @@ package org.anon.spareuse.core.model.analysis
 
 import spray.json._
 
-case class RunnerCommand(analysisName: String, runId: String, userName: String, inputEntityNames: Set[String], configurationRaw: String){
+trait RunnerCommand{
+  val analysisName: String
+
+  val associatedRunId: String
+
+  val userName: String
+
+  val inputEntityNames: Set[String]
+
+  val configurationRaw: String
+
+  def updateRunId(newRunId: String): RunnerCommand
+
+
+}
+
+
+case class AnalysisCommand(override val analysisName: String,
+                           override val associatedRunId: String,
+                           override val userName: String,
+                           override val inputEntityNames: Set[String],
+                           override val configurationRaw: String) extends RunnerCommand {
   def updateRunId(newRunId: String): RunnerCommand = {
-    RunnerCommand(analysisName, newRunId, userName, inputEntityNames, configurationRaw)
+    AnalysisCommand(analysisName, newRunId, userName, inputEntityNames, configurationRaw)
+  }
+
+  def asIncremental(baselineRunId: Option[String]): RunnerCommand =
+    IncrementalAnalysisCommand(analysisName, associatedRunId, userName, inputEntityNames, configurationRaw, baselineRunId.getOrElse(""))
+}
+
+case class IncrementalAnalysisCommand(override val analysisName: String,
+                                      override val associatedRunId: String,
+                                      override val userName: String,
+                                      override val inputEntityNames: Set[String],
+                                      override val configurationRaw: String,
+                                      baselineRunId: String) extends RunnerCommand {
+  override def updateRunId(newRunId: String): RunnerCommand = {
+    IncrementalAnalysisCommand(analysisName, newRunId, userName, inputEntityNames, configurationRaw, baselineRunId)
   }
 }
 
 
 trait RunnerCommandJsonSupport extends DefaultJsonProtocol {
-  implicit val runnerCommandFormat: JsonFormat[RunnerCommand] = jsonFormat5(RunnerCommand)
+
+  implicit val runnerCommandFormat: JsonFormat[RunnerCommand] = new JsonFormat[RunnerCommand] {
+    override def write(obj: RunnerCommand): JsValue = obj match {
+      case ac: AnalysisCommand =>
+        analysisCommandFormat.write(ac)
+      case iac: IncrementalAnalysisCommand =>
+        incrementalAnalysisCommandFormat.write(iac)
+      case x@_ =>
+        throw new SerializationException(s"Unsupported runner command type ${x.getClass}")
+    }
+
+    override def read(json: JsValue): RunnerCommand = json match {
+      case jo: JsObject =>
+        if(jo.fields.contains("baselineRunId")) incrementalAnalysisCommandFormat.read(jo)
+        else analysisCommandFormat.read(jo)
+      case x@_ =>
+        throw DeserializationException(s"Unsupported JSON format for runner commands, Object expected but got ${x.getClass}")
+    }
+  }
+
+  implicit val analysisCommandFormat: JsonFormat[AnalysisCommand] = jsonFormat5(AnalysisCommand)
+  implicit val incrementalAnalysisCommandFormat: JsonFormat[IncrementalAnalysisCommand] = jsonFormat6(IncrementalAnalysisCommand)
 }

--- a/core/src/main/scala/org/anon/spareuse/core/model/entities/JavaEntities.scala
+++ b/core/src/main/scala/org/anon/spareuse/core/model/entities/JavaEntities.scala
@@ -66,13 +66,13 @@ object JavaEntities {
     val identifier: String = entityIdent
   }
 
-  class JavaLibrary(libraryName: String,
+  class JavaLibrary(val libraryName: String,
                     repositoryIdent: String) extends PathIdentifiableJavaEntity(libraryName, libraryName, libraryName, repositoryIdent, None){
     override val kind: SoftwareEntityKind = SoftwareEntityKind.Library
   }
 
-  class JavaProgram(programName: String,
-                    programIdent: String,
+  class JavaProgram(val programName: String,
+                    val programIdent: String,
                     programUid: String,
                     repositoryIdent: String,
                     hashedBytes: Array[Byte]) extends PathIdentifiableJavaEntity(programName, programIdent, programUid, repositoryIdent, Some(hashedBytes)) {

--- a/core/src/main/scala/org/anon/spareuse/core/model/entities/SoftwareEntityData.scala
+++ b/core/src/main/scala/org/anon/spareuse/core/model/entities/SoftwareEntityData.scala
@@ -1,7 +1,9 @@
 package org.anon.spareuse.core.model.entities
 
+import org.anon.spareuse.core.model.SoftwareEntityKind
 import org.anon.spareuse.core.model.SoftwareEntityKind.SoftwareEntityKind
 
+import scala.annotation.tailrec
 import scala.collection.mutable
 
 trait SoftwareEntityData {
@@ -40,5 +42,21 @@ trait SoftwareEntityData {
   def hasParent: Boolean = parent.isDefined
 
   def getParent: Option[SoftwareEntityData] = parent
+
+  def isLibrary: Boolean = kind == SoftwareEntityKind.Library
+  def isProgram: Boolean = kind == SoftwareEntityKind.Program
+  def isPackage: Boolean = kind == SoftwareEntityKind.Package
+  def isClass: Boolean = kind == SoftwareEntityKind.Class
+  def isMethod: Boolean = kind == SoftwareEntityKind.Method
+  def isFieldAccessInstruction: Boolean = kind == SoftwareEntityKind.FieldAccessStatement
+  def isMethodInvocationInstruction: Boolean = kind == SoftwareEntityKind.InvocationStatement
+  def isInstruction: Boolean = isFieldAccessInstruction || isMethodInvocationInstruction
+
+  @tailrec
+  final def findFirstParent(pred: SoftwareEntityData => Boolean): Option[SoftwareEntityData] = {
+    if(pred(this)) Some(this)
+    else if(!hasParent) None
+    else getParent.get.findFirstParent(pred)
+  }
 
 }

--- a/core/src/main/scala/org/anon/spareuse/core/storage/AnalysisAccessor.scala
+++ b/core/src/main/scala/org/anon/spareuse/core/storage/AnalysisAccessor.scala
@@ -49,6 +49,8 @@ trait AnalysisAccessor {
 
   def hasAnalysis(analysisName: String): Boolean
 
+  def isIncrementalAnalysis(analysisName: String, analysisVersion: String): Boolean
+
   def hasAnalysisRun(analysisName: String, analysisVersion: String, runUid: String): Boolean
 
   /**

--- a/core/src/main/scala/org/anon/spareuse/core/storage/AnalysisAccessor.scala
+++ b/core/src/main/scala/org/anon/spareuse/core/storage/AnalysisAccessor.scala
@@ -26,7 +26,21 @@ trait AnalysisAccessor {
 
   def storeEmptyAnalysisRun(analysisName: String, analysisVersion: String, runConfig: String): Try[String]
 
-  def setRunResults(runUid: String, timeStamp: LocalDateTime, logs: Array[String], results: Set[AnalysisResultData])(implicit serializer: JsonWriter[Object]): Try[Unit]
+  /**
+   * Sets the results for a given run, as well as its timestamp and logs. Will set the run's state to 'Finished'.
+   * @param runUid UID of the run to set results for
+   * @param timeStamp Timestamp to associate with the given run
+   * @param logs Logs to associated with the given run
+   * @param freshResults Results freshly introduced with this run, i.e. not existing in the DB so far
+   * @param unchangedResultIds IDs of results that already exist in the DB, and are also valid (without changes) for the given run
+   * @param serializer Serializer for results produced by this run
+   * @return Unit if successful, Failure otherwise
+   */
+  def setRunResults(runUid: String,
+                    timeStamp: LocalDateTime,
+                    logs: Array[String],
+                    freshResults: Set[AnalysisResultData],
+                    unchangedResultIds: Set[String])(implicit serializer: JsonWriter[Object]): Try[Unit]
 
   /**
    * This Method retrieves all results for the given run, but does not deserialize the contents into an actual object

--- a/core/src/main/scala/org/anon/spareuse/core/storage/postgresql/PostgresDataAccessor.scala
+++ b/core/src/main/scala/org/anon/spareuse/core/storage/postgresql/PostgresDataAccessor.scala
@@ -47,6 +47,7 @@ class PostgresDataAccessor extends DataAccessor {
   private val resultFormatsTable = TableQuery[ResultFormats]
   private val nestedResultFormatsTable = TableQuery[NestedResultFormatReferences]
   private val resultValiditiesTable = TableQuery[AnalysisResultValidities]
+  private val runResultsTable = TableQuery[AnalysisRunResultRelations]
 
   private lazy val idReturningAnalysisRunTable = analysisRunsTable returning analysisRunsTable.map(_.id)
   private lazy val idReturningFormatTable = resultFormatsTable returning resultFormatsTable.map(_.id)
@@ -68,7 +69,7 @@ class PostgresDataAccessor extends DataAccessor {
   override def initializeAnalysisTables(): Unit = {
     val setupAction = DBIO.seq(resultFormatsTable.schema.createIfNotExists, nestedResultFormatsTable.schema.createIfNotExists,
       analysesTable.schema.createIfNotExists, analysisRunsTable.schema.createIfNotExists, analysisRunInputsTable.schema.createIfNotExists,
-      analysisResultsTable.schema.createIfNotExists, resultValiditiesTable.schema.createIfNotExists)
+      analysisResultsTable.schema.createIfNotExists, resultValiditiesTable.schema.createIfNotExists, runResultsTable.schema.createIfNotExists)
 
     val setupF = db.run(setupAction)
 
@@ -593,7 +594,12 @@ class PostgresDataAccessor extends DataAccessor {
     }
   }
 
-  override def setRunResults(runUid: String, timeStamp: LocalDateTime, logs: Array[String], results: Set[AnalysisResultData])(implicit serializer: JsonWriter[Object]): Try[Unit] = Try {
+  override def setRunResults(runUid: String,
+                             timeStamp: LocalDateTime,
+                             logs: Array[String],
+                             freshResults: Set[AnalysisResultData],
+                             unchangedResultIds: Set[String])(implicit serializer: JsonWriter[Object]): Try[Unit] = Try {
+
     val runRepr: SoftwareAnalysisRunRepr = getRunRepr(runUid)
     setRunState(runRepr.id, RunState.Finished.id)
 
@@ -606,7 +612,7 @@ class PostgresDataAccessor extends DataAccessor {
     Await.ready(updateTimeStampAction, simpleQueryTimeout)
     Await.ready(updateLogsAction, simpleQueryTimeout)
 
-    results.foreach{ runResult =>
+    val newResultIds = freshResults.map{ runResult =>
       // Serialize result content
       val content = serializer.write(runResult.content).compactPrint
       val resultDbObj = AnalysisResult(-1, runResult.uid, runRepr.id, runResult.isRevoked, content)
@@ -619,11 +625,24 @@ class PostgresDataAccessor extends DataAccessor {
         Await.ready(db.run(resultValiditiesTable += AnalysisResultValidity(-1, resultDbId, affectedEntityId)), simpleQueryTimeout)
       }
 
+      resultDbId
+    }
 
+
+    val resultDbIdsAction = db.run(analysisResultsTable.filter(r => r.uid inSet unchangedResultIds).map(_.id).result)
+    val unchangedResultIdsInDb = Await.result(resultDbIdsAction, simpleQueryTimeout)
+
+    (newResultIds ++ unchangedResultIdsInDb).foreach{ resultDbId =>
+      Await.ready(db.run(runResultsTable += AnalysisRunResultRelation(-1, runRepr.id, resultDbId)), simpleQueryTimeout )
     }
   }
 
   override def getRunResultsAsJSON(runUid: String, skip: Int = 0, limit: Int = 100): Try[Set[AnalysisResultData]] = Try {
+
+
+    //TODO: A result may be valid for multiple runs. This must be reflected in the core data model and retrieved via the corresponding table
+    ???
+
     val runRepr: SoftwareAnalysisRunRepr = getRunRepr(runUid)
 
     val resQuery = db.run(analysisResultsTable.filter(r => r.runID === runRepr.id).sortBy(_.id).drop(skip).take(limit).result)
@@ -691,6 +710,9 @@ class PostgresDataAccessor extends DataAccessor {
   }
 
   override def getJSONResultsFor(entityName: String, analysisFilter: Option[(String, String)], limit: Int, skip: Int): Try[Set[AnalysisResultData]] = Try {
+
+    //TODO: Reflect that result belongs to multiple runs
+    ???
 
     val eid = getEntityId(entityName)
 

--- a/core/src/main/scala/org/anon/spareuse/core/storage/postgresql/PostgresDataAccessor.scala
+++ b/core/src/main/scala/org/anon/spareuse/core/storage/postgresql/PostgresDataAccessor.scala
@@ -825,4 +825,9 @@ class PostgresDataAccessor extends DataAccessor {
     val queryF = db.run(entitiesTable.filter( e => e.qualifier === ident).exists.result)
     Await.result(queryF, simpleQueryTimeout)
   }
+
+  override def isIncrementalAnalysis(analysisName: String, analysisVersion: String): Boolean = {
+    //TODO: Implement this
+    ???
+  }
 }

--- a/core/src/main/scala/org/anon/spareuse/core/storage/postgresql/PostgresDataAccessor.scala
+++ b/core/src/main/scala/org/anon/spareuse/core/storage/postgresql/PostgresDataAccessor.scala
@@ -826,8 +826,11 @@ class PostgresDataAccessor extends DataAccessor {
     Await.result(queryF, simpleQueryTimeout)
   }
 
-  override def isIncrementalAnalysis(analysisName: String, analysisVersion: String): Boolean = {
-    //TODO: Implement this
-    ???
+  override def isIncrementalAnalysis(analysisName: String, analysisVersion: String): Boolean = Try {
+    val queryF = db.run(analysesTable.filter(a => a.name === analysisName && a.version === analysisVersion).map(_.isIncremental).result)
+
+    val queryResult = Await.result(queryF, simpleQueryTimeout)
+
+    queryResult.nonEmpty && queryResult.head
   }
 }

--- a/core/src/main/scala/org/anon/spareuse/core/storage/postgresql/postgresql.scala
+++ b/core/src/main/scala/org/anon/spareuse/core/storage/postgresql/postgresql.scala
@@ -153,6 +153,25 @@ package object postgresql {
 
   }
 
+  case class AnalysisRunResultRelation(id: Long, analysisRunId: Long, analysisResultId: Long)
+
+  class AnalysisRunResultRelations(tag: Tag) extends Table[AnalysisRunResultRelation](tag, "analysisrunresults"){
+    def id: Rep[Long] = column[Long]("ID", O.PrimaryKey, O.AutoInc)
+
+    def analysisRunID: Rep[Long] = column[Long]("ANALYSIS_RUN_ID")
+
+    def resultID: Rep[Long] = column[Long]("RESULT_ID")
+
+    override def * : ProvenShape[AnalysisRunResultRelation] =
+      (id, analysisRunID, resultID) <> ((AnalysisRunResultRelation.apply _ ).tupled, AnalysisRunResultRelation.unapply)
+
+    def analysisRun: ForeignKeyQuery[SoftwareAnalysisRuns, SoftwareAnalysisRunRepr] =
+      foreignKey("RUN_FK", analysisRunID, TableQuery[SoftwareAnalysisRuns])(_.id)
+
+    def result: ForeignKeyQuery[AnalysisResults, AnalysisResult] =
+      foreignKey("RESULT_FK", resultID, TableQuery[AnalysisResults])(_.id)
+  }
+
   case class AnalysisResult(id: Long, uid: String, runId: Long, isRevoked: Boolean, jsonContent: String)
 
   class AnalysisResults(tag: Tag) extends Table[AnalysisResult](tag, "analysisresults"){

--- a/core/src/test/scala/org/anon/spareuse/core/testutils/AnalysisTestDataFactory.scala
+++ b/core/src/test/scala/org/anon/spareuse/core/testutils/AnalysisTestDataFactory.scala
@@ -1,0 +1,19 @@
+package org.anon.spareuse.core.testutils
+
+import org.anon.spareuse.core.model.RunState.RunState
+import org.anon.spareuse.core.model.{AnalysisResultData, AnalysisRunData, RunState}
+import org.anon.spareuse.core.model.entities.SoftwareEntityData
+
+import java.time.LocalDateTime
+
+object AnalysisTestDataFactory {
+
+  def stringResult(content: String, affects: Set[SoftwareEntityData], uid: String = "NULL", runUid: String = "NULL"): AnalysisResultData = {
+    AnalysisResultData(uid, isRevoked = false, runUid, content, affects)
+  }
+
+  def analysisRun(analysisName: String, analysisVersion: String, results: Set[AnalysisResultData], inputs: Set[SoftwareEntityData], state: RunState = RunState.Finished, config: String = ""): AnalysisRunData = {
+    AnalysisRunData("NULL", LocalDateTime.now(), Array.empty, config, state, isRevoked = false, inputs, results, analysisName, analysisVersion)
+  }
+
+}

--- a/core/src/test/scala/org/anon/spareuse/core/testutils/SoftwareEntityTestDataFactory.scala
+++ b/core/src/test/scala/org/anon/spareuse/core/testutils/SoftwareEntityTestDataFactory.scala
@@ -1,4 +1,4 @@
-package org.anon.spareuse.testutils
+package org.anon.spareuse.core.testutils
 
 import org.anon.spareuse.core.model.SoftwareEntityKind
 import org.anon.spareuse.core.model.SoftwareEntityKind.SoftwareEntityKind

--- a/core/src/test/scala/org/anon/spareuse/core/testutils/SoftwareEntityTestDataFactory.scala
+++ b/core/src/test/scala/org/anon/spareuse/core/testutils/SoftwareEntityTestDataFactory.scala
@@ -2,7 +2,8 @@ package org.anon.spareuse.core.testutils
 
 import org.anon.spareuse.core.model.SoftwareEntityKind
 import org.anon.spareuse.core.model.SoftwareEntityKind.SoftwareEntityKind
-import org.anon.spareuse.core.model.entities.{GenericEntityData, SoftwareEntityData}
+import org.anon.spareuse.core.model.entities.JavaEntities.{JavaClass, JavaMethod}
+import org.anon.spareuse.core.model.entities.{GenericEntityData, JavaEntities, SoftwareEntityData}
 
 object SoftwareEntityTestDataFactory {
 
@@ -24,4 +25,25 @@ object SoftwareEntityTestDataFactory {
                     repository: String = "Maven"): SoftwareEntityData =
     new GenericEntityData(name, language, kind, repository, None, uid, None)
 
+
+
+  def fullMethodEntity(gav: String, packageName: String, className: String, methodName: String, returnType: String = "String", paramTypeNames: Seq[String] = Seq.empty): JavaMethod = {
+    assert(gav.count(_ == ':') == 2)
+
+    val lib = JavaEntities.buildLibrary(gav.substring(0, gav.lastIndexOf(':')))
+    val prog = JavaEntities.buildProgramFor(lib, gav)
+    val pack = JavaEntities.buildPackageFor(prog, packageName)
+    val classObj = JavaEntities.buildClassFor(pack,
+      className,
+      className,
+      isInterface = false,
+      isFinal = false,
+      isAbstract = false)
+
+    methodFor(classObj, methodName, returnType, paramTypeNames)
+  }
+
+  def methodFor(jc: JavaClass, methodName: String = "toString", returnType: String = "String", paramTypeNames: Seq[String] = Seq.empty, isFinal: Boolean = false, isStatic: Boolean = false, isAbstract: Boolean = false, visibility: String = "public"): JavaMethod = {
+    JavaEntities.buildMethodFor(jc, methodName, returnType, paramTypeNames, isFinal, isStatic, isAbstract, visibility)
+  }
 }

--- a/core/src/test/scala/org/anon/spareuse/testutils/SoftwareEntityTestDataFactory.scala
+++ b/core/src/test/scala/org/anon/spareuse/testutils/SoftwareEntityTestDataFactory.scala
@@ -1,0 +1,27 @@
+package org.anon.spareuse.testutils
+
+import org.anon.spareuse.core.model.SoftwareEntityKind
+import org.anon.spareuse.core.model.SoftwareEntityKind.SoftwareEntityKind
+import org.anon.spareuse.core.model.entities.{GenericEntityData, SoftwareEntityData}
+
+object SoftwareEntityTestDataFactory {
+
+  /**
+   * Build a generic entity data object with no hash and no parent. If no arguments are supplied, a default dummy entity
+   * of type 'Program' is returned.
+   *
+   * @param name Name for the generic entity
+   * @param uid UID for the generic entity - ensure consistency to name if needed
+   * @param kind Kind for the generic entity - defaults to 'Program'
+   * @param language Language for the generic entity - defaults to 'Java'
+   * @param repository Repository for the generic entity - default to 'Maven'
+   * @return GenericEntityData object with no parent
+   */
+  def genericEntity(name: String = "dummy.group:artifact:1.0.0",
+                    uid: String = "dummy.group!dummy.group:artifact:1.0.0",
+                    kind: SoftwareEntityKind = SoftwareEntityKind.Program,
+                    language: String = "Java",
+                    repository: String = "Maven"): SoftwareEntityData =
+    new GenericEntityData(name, language, kind, repository, None, uid, None)
+
+}

--- a/webapi/src/main/scala/org/anon/spareuse/webapi/model/requests/ExecuteAnalysisRequest.scala
+++ b/webapi/src/main/scala/org/anon/spareuse/webapi/model/requests/ExecuteAnalysisRequest.scala
@@ -1,3 +1,3 @@
 package org.anon.spareuse.webapi.model.requests
 
-final case class ExecuteAnalysisRequest(Inputs: Array[String], Configuration: String, User: Option[String])
+final case class ExecuteAnalysisRequest(Inputs: Array[String], Configuration: String, User: Option[String], BaselineRun: Option[String])

--- a/webapi/src/main/scala/org/anon/spareuse/webapi/model/requests/RequestsJsonSupport.scala
+++ b/webapi/src/main/scala/org/anon/spareuse/webapi/model/requests/RequestsJsonSupport.scala
@@ -7,6 +7,6 @@ trait RequestsJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
 
   implicit val enqueueRequestFormat: JsonFormat[EnqueueRequest] = jsonFormat1(EnqueueRequest)
 
-  implicit val executeAnalysisRequestFormat: JsonFormat[ExecuteAnalysisRequest] = jsonFormat3(ExecuteAnalysisRequest)
+  implicit val executeAnalysisRequestFormat: JsonFormat[ExecuteAnalysisRequest] = jsonFormat4(ExecuteAnalysisRequest)
 
 }


### PR DESCRIPTION
This PR introduces some changes to the core data model. The main change is that an `AnalysisResult` is now *produced* by one single run (as before), but may be valid for multiple runs, e.g. when an incremental analysis is performed on a piece of code that has not changed. Furthermore, the data model now reflects whether an analysis is incremtental and allows batch processing (was not part of core model before).

Also, this PR introduces an abstract implementation of built-in incremental analyses, which handles the mapping of previous to current results, and does all necessary data validation. This prompted some general changes to the `AnalysisRunner` as it now needs to supply information about the baseline analysis run if an incremental analysis is triggered. Currently there are only anonymous implementations of the `IncrementalAnalysisImplementation` interface - which are used for unit testing - but no real implementations yet.