### PR TITLE
Cleanup Entity Miner Storage Precedure

### DIFF
--- a/core/src/main/scala/org/anon/spareuse/core/utils/rabbitmq/MqStreamIntegration.scala
+++ b/core/src/main/scala/org/anon/spareuse/core/utils/rabbitmq/MqStreamIntegration.scala
@@ -19,8 +19,8 @@ trait MqStreamIntegration {
   def createMqMessageSource(config: MqConnectionConfiguration, abortOnEmptyQueue: Boolean): Source[String, NotUsed] = {
 
     var sourceSettings = RestartSettings.create(minBackoff = Duration.ofSeconds(10),
-      maxBackoff = Duration.ofSeconds(60), randomFactor = 0.2)
-      .withMaxRestarts(100, 5.minutes) // Always restart and never cancel
+      maxBackoff = Duration.ofSeconds(10), randomFactor = 0.2)
+      .withMaxRestarts(1000, 5.minutes) // Always restart and never cancel
 
     if(!abortOnEmptyQueue) // Suppress error output when we do not abort on empty queue -> Don't print EmptyQueueExceptions
       sourceSettings = sourceSettings.withLogSettings(sourceSettings.logSettings.withLogLevel(Logging.DebugLevel))

--- a/maven-entity-miner/src/main/resources/logback.xml
+++ b/maven-entity-miner/src/main/resources/logback.xml
@@ -6,7 +6,7 @@
         </encoder>
     </appender>
 
-    <!--logger name="org.anon.spareuse.mvnem.storage.impl" level="debug"/-->
+    <logger name="org.anon.spareuse.mvnem.storage.impl" level="debug"/>
 
     <root level="info">
         <appender-ref ref="CONSOLE"/>

--- a/maven-entity-miner/src/main/scala/org/anon/spareuse/mvnem/MavenEntityMiner.scala
+++ b/maven-entity-miner/src/main/scala/org/anon/spareuse/mvnem/MavenEntityMiner.scala
@@ -15,7 +15,8 @@ import org.anon.spareuse.mvnem.storage.EntityMinerStorageAdapter
 import org.anon.spareuse.mvnem.storage.impl.PostgresStorageAdapter
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, Future}
 import scala.language.implicitConversions
 import scala.util.{Failure, Success, Try}
 
@@ -50,12 +51,11 @@ class MavenEntityMiner(private[mvnem] val configuration: EntityMinerConfig)
 
   override protected def buildStreamPipeline(source: Source[String, NotUsed]): Future[Done] = {
     source
-      .map(getJarsForMessage)
-      .map(extractEntities)
-      .runWith(buildStorageSink())(streamMaterializer)
+      .map(getIdentifiersForMessage)
+      .runWith(storeAllEntitiesSink)(streamMaterializer)
   }
 
-  private def getJarsForMessage(message: String): ResolvedMinerCommand = {
+  private def getIdentifiersForMessage(message: String): Set[MavenIdentifier] = {
 
     val command = Try(message.parseJson.convertTo[MinerCommand]) match {
       case Success(mc) => mc
@@ -76,7 +76,9 @@ class MavenEntityMiner(private[mvnem] val configuration: EntityMinerConfig)
     if(allIdentifiers.nonEmpty && allNewIdentifiers.isEmpty)
       log.info(s"All programs already indexed for message $message")
 
-    val allJars = allNewIdentifiers.flatMap { ident =>
+    allNewIdentifiers
+
+    /*val allJars = allNewIdentifiers.flatMap { ident =>
       downloader.downloadJar(ident) match {
         case Success(jarFile) => Some(jarFile)
         case Failure(HttpDownloadException(404, _, _)) =>
@@ -88,29 +90,53 @@ class MavenEntityMiner(private[mvnem] val configuration: EntityMinerConfig)
       }
     }
 
-    ResolvedMinerCommand(command, allJars)
+    ResolvedMinerCommand(command, allJars)*/
   }
 
-  def extractEntities(command: ResolvedMinerCommand): TransformedMinerCommand = {
-    val entities = command.jars.flatMap(transform)
-
-    TransformedMinerCommand(command.cmd, entities)
-  }
-
-  def storeEntities(command: TransformedMinerCommand): Future[Unit] = {
-    val f: Future[Unit] = Future.sequence(command.entities.map(store)).map( _ => {})
-
-    f.onComplete { _ =>
-      if(command.cmd.analysisToTrigger.isDefined){
-        val analysisCommand = command.cmd.analysisToTrigger.get
-        log.info(s"Rescheduling analysis ${analysisCommand.analysisName} after mining of ${analysisCommand.inputEntityNames.size} input(s) has been completed.")
-        analysisQueueWriter.appendToQueue(analysisCommand.toJson.compactPrint)
-      }
+  def downloadJar(identifier: MavenIdentifier): Option[MavenOnlineJar] = {
+    downloader.downloadJar(identifier) match {
+      case Success(jarFile) => Some(jarFile)
+      case Failure(HttpDownloadException(404, _, _)) =>
+        // Do nothing when JAR does not exist
+        None
+      case Failure(ex) =>
+        throw ex
     }
-
-    f
   }
 
+  def storeAllEntitiesSink: Sink[Set[MavenIdentifier], Future[Done]] = {
+    Sink.foreach { identifiers =>
+
+      var cnt = 0
+      var err = 0
+
+      identifiers.foreach { identifier =>
+
+        log.info(s"[$cnt/${identifiers.size}] Start processing ${identifier.toString} ... ")
+
+        Try{
+          downloadJar(identifier) match {
+            case Some(jarFile) =>
+              val representation = transform(jarFile)
+              log.info(s"[$cnt/${identifiers.size}] Starting to store program for ${identifier.toString} ... ")
+              storageAdapter.storeJavaProgram(representation).get
+            case None =>
+              // Do nothing, this is a GAV without a JAR
+          }
+        } match {
+          case Success(_) =>
+            log.info(s"[$cnt/${identifiers.size}] Done storing program for ${identifier.toString}.")
+            cnt += 1
+          case Failure(ex) =>
+            log.error(s"[$cnt/${identifiers.size}] Failed to handle identifier ${identifier.toString}", ex)
+            cnt += 1
+            err += 1
+        }
+      }
+
+      log.info(s"Processed $cnt identifiers for message, got $err errors")
+    }
+  }
 
   /**
    * Method that extracts the program identifiers to process for a given message. The miner processes plain string messages,
@@ -163,7 +189,7 @@ class MavenEntityMiner(private[mvnem] val configuration: EntityMinerConfig)
    * @param jarFile JAR file with an open input stream
    * @return Data on Software Entity. Result will be of 'Program' Kind, and may have children that also need to be stored
    */
-  private def transform(jarFile: MavenOnlineJar): Option[JavaProgram] = {
+  private def transform(jarFile: MavenOnlineJar): JavaProgram = {
 
     val start = System.currentTimeMillis()
     val classesTry = opalProjectHelper.readClassesFromJarStream(jarFile.content, jarFile.url, loadImplementation = true)
@@ -171,7 +197,7 @@ class MavenEntityMiner(private[mvnem] val configuration: EntityMinerConfig)
 
     log.debug(s"OPAL init took $duration ms for ${jarFile.identifier.toString}")
 
-    var result: Option[JavaProgram] = None
+    var result: JavaProgram = null
 
     classesTry match {
       case Success(classes) =>
@@ -182,43 +208,23 @@ class MavenEntityMiner(private[mvnem] val configuration: EntityMinerConfig)
           case Success(programRep) =>
             programRep.setParent(new JavaLibrary(jarFile.identifier.toGA, "central"))
             log.info(s"Processing ${classes.size} classes in ${programRep.getChildren.size} packages @  ${jarFile.url.toString}")
-            result = Some(programRep)
+            result = programRep
           case Failure(ex) =>
             log.error(s"Failed to extract program entities @ ${jarFile.url.toString}", ex)
-
+            throw ex
         }
 
       case Failure(ex) =>
-        log.error(s"Failed to process ${jarFile.identifier.toString}", ex)
+        log.error(s"Failed to read classes from JAR file @ ${jarFile.identifier.toString}", ex)
+        throw ex
     }
 
     jarFile.content.close()
+    opalProjectHelper.freeOpalResources()
 
     result
   }
 
-  private def store(data: JavaProgram): Future[Unit] = {
-    log.info("Storing program " + data.name + " ...")
-    storageAdapter.storeJavaProgram(data).map(_ => ())(streamMaterializer.executionContext)
-  }
-
-  private[mvnem] def buildStorageSink(): Sink[TransformedMinerCommand, Future[Done]] = {
-    Sink.foreachAsync(configuration.storageParallel) { data =>
-
-      storeEntities(data).andThen {
-        case Success(_) =>
-          val label = if (data.entities.size == 1) data.entities.head.name else s"${data.entities.size} program(s)"
-          log.info(s"Successfully stored $label for command")
-        case Failure(ex) =>
-          log.error(s"Failed to store ${data.entities.size} program(s) for command ${data.cmd}", ex)
-      }(streamMaterializer.executionContext)
-
-    }
-  }
-
-
-  case class ResolvedMinerCommand(cmd: MinerCommand, jars: Set[MavenOnlineJar])
-  case class TransformedMinerCommand(cmd:MinerCommand, entities: Set[JavaProgram])
 
 
 }

--- a/maven-entity-miner/src/main/scala/org/anon/spareuse/mvnem/MavenEntityMiner.scala
+++ b/maven-entity-miner/src/main/scala/org/anon/spareuse/mvnem/MavenEntityMiner.scala
@@ -77,20 +77,6 @@ class MavenEntityMiner(private[mvnem] val configuration: EntityMinerConfig)
       log.info(s"All programs already indexed for message $message")
 
     allNewIdentifiers
-
-    /*val allJars = allNewIdentifiers.flatMap { ident =>
-      downloader.downloadJar(ident) match {
-        case Success(jarFile) => Some(jarFile)
-        case Failure(HttpDownloadException(404, _, _)) =>
-          // Do nothing when JAR does not exist
-          None
-        case Failure(ex) =>
-          log.error(s"Failed to download JAR file for ${ident.toUniqueString}", ex)
-          None
-      }
-    }
-
-    ResolvedMinerCommand(command, allJars)*/
   }
 
   def downloadJar(identifier: MavenIdentifier): Option[MavenOnlineJar] = {
@@ -129,6 +115,7 @@ class MavenEntityMiner(private[mvnem] val configuration: EntityMinerConfig)
             cnt += 1
           case Failure(ex) =>
             log.error(s"[$cnt/${identifiers.size}] Failed to handle identifier ${identifier.toString}", ex)
+            storageAdapter.ensureNotPresent(s"${identifier.toGA}!${identifier.toString}")
             cnt += 1
             err += 1
         }

--- a/maven-entity-miner/src/main/scala/org/anon/spareuse/mvnem/storage/EntityMinerStorageAdapter.scala
+++ b/maven-entity-miner/src/main/scala/org/anon/spareuse/mvnem/storage/EntityMinerStorageAdapter.scala
@@ -12,6 +12,8 @@ trait EntityMinerStorageAdapter {
 
   def storeJavaProgram(data: JavaProgram): Try[Unit]
 
+  def ensureNotPresent(programUid: String): Unit
+
   def hasEntityQualifier(fq: String): Boolean
 
   def hasProgram(gav: String): Boolean = {

--- a/maven-entity-miner/src/main/scala/org/anon/spareuse/mvnem/storage/EntityMinerStorageAdapter.scala
+++ b/maven-entity-miner/src/main/scala/org/anon/spareuse/mvnem/storage/EntityMinerStorageAdapter.scala
@@ -4,12 +4,13 @@ import org.anon.spareuse.core.model.entities.JavaEntities.JavaProgram
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.concurrent.Future
+import scala.util.Try
 
 trait EntityMinerStorageAdapter {
 
   protected val log: Logger = LoggerFactory.getLogger(getClass)
 
-  def storeJavaProgram(data: JavaProgram): Future[_]
+  def storeJavaProgram(data: JavaProgram): Try[Unit]
 
   def hasEntityQualifier(fq: String): Boolean
 

--- a/maven-entity-miner/src/main/scala/org/anon/spareuse/mvnem/storage/impl/PostgresStorageAdapter.scala
+++ b/maven-entity-miner/src/main/scala/org/anon/spareuse/mvnem/storage/impl/PostgresStorageAdapter.scala
@@ -1,6 +1,5 @@
 package org.anon.spareuse.mvnem.storage.impl
 
-import kotlin.reflect.jvm.internal.JvmPropertySignature.JavaField
 import org.anon.spareuse.core.model.entities.JavaEntities.{JavaClass, JavaFieldAccessStatement, JavaInvokeStatement, JavaMethod, JavaNewInstanceStatement, JavaPackage, JavaProgram, JavaStatement}
 import org.anon.spareuse.core.model.entities.SoftwareEntityData
 import org.anon.spareuse.core.storage.postgresql.JavaDefinitions.{JavaClassRepr, JavaClasses, JavaFieldAccessRepr, JavaFieldAccessStatements, JavaInvocationRepr, JavaInvocationStatements, JavaMethodRepr, JavaMethods}
@@ -8,7 +7,7 @@ import org.anon.spareuse.core.storage.postgresql.{SoftwareEntities, SoftwareEnti
 import org.anon.spareuse.core.utils.toHex
 import org.anon.spareuse.mvnem.storage.EntityMinerStorageAdapter
 
-import scala.util.{Failure, Success, Try}
+import scala.util.Try
 import slick.jdbc.PostgresProfile.api._
 
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -30,33 +29,63 @@ class PostgresStorageAdapter(implicit executor: ExecutionContext) extends Entity
   // Converts representations of binary hashes in the core model (byte-array) to database-representations (hex-strings)
   private implicit def toHexOpt(byteOpt: Option[Array[Byte]]): Option[String] = byteOpt.map(toHex)
 
-  override def storeJavaProgram(data: JavaProgram): Future[_] =  {
 
-    Try{
-      data.getParent.map(p => {
-        if (hasEntityQualifier(p.uid)) {
-          getIdForQualifier(p.uid)
-        } else {
-          storeDataAndGetId(p, None)
-        }
-      })
-    } match {
-      case Success(parentIdOpt) =>
-        storeInternal(data, parentIdOpt)
-      case Failure(ex) =>
-        log.error(s"Failed to prepare storage of program: ${data.name}", ex)
-        Future.failed(ex)
+  override def storeJavaProgram(jp: JavaProgram): Try[Unit] = Try {
+
+    // Create parent if it does not already exist, get uid of parent entity
+    val parentIdOpt = jp.getParent.map(p => {
+      if (hasEntityQualifier(p.uid)) {
+        getIdForQualifier(p.uid)
+      } else {
+        storeDataAndGetId(p, None)
+      }
+    })
+
+    // Programs don't have a separate additional table, so they only need this one insert
+    val programId = storeDataAndGetId(jp, parentIdOpt)
+
+    def storeEntitiesTimed(entities: Set[SoftwareEntityData], parentIdLookup: Map[String, Long], batchSize: Int, kindName: String): Map[String, Long] = {
+      val timeout = Math.max((entities.size / 100) * 10, 30).seconds // 10 seconds for every 100 entities, at least 30 seconds
+      val start = System.currentTimeMillis()
+      val result = Await.result(insertEntitiesBatchedWithMapReturn(entities, parentIdLookup, batchSize), timeout)
+      val time = System.currentTimeMillis() - start
+      log.debug(s"Successfully stored ${entities.size} entities of kind $kindName for program ${jp.name} in $time ms.")
+      result
+    }
+
+    val packageLookup = storeEntitiesTimed(jp.getChildren, Map(jp.uid -> programId), 30, "Package")
+    val allClasses = jp.getChildren.flatMap(_.getChildren)
+    val classLookup = storeEntitiesTimed(allClasses, packageLookup, 50, "Class")
+    val allMethods = allClasses.flatMap(_.getChildren)
+    val methodLookup = storeEntitiesTimed(allMethods, classLookup, 50, "Methods")
+    val allStatements = allMethods.flatMap(_.getChildren)
+    storeEntitiesTimed(allStatements, methodLookup, 100, "Statements")
+
+  }
+
+  private[storage] def insertEntitiesBatchedWithMapReturn(entities: Set[SoftwareEntityData], parentIdLookup: Map[String, Long], batchSize: Int): Future[Map[String, Long]] = {
+    val entityReprs = entities.map(e => toEntityRepr(e, parentIdLookup.get(e.uid)))
+
+    batchedEntityInsertWithMapReturn(entityReprs, batchSize).flatMap { theMap =>
+      entities.headOption match {
+        case Some(_: JavaClass) =>
+          val allClasses = entities.filter(_.isInstanceOf[JavaClass]).map{ case jc: JavaClass => toClassRepr(jc, theMap(jc.uid)) }.toSeq
+          batchedClassInsert(allClasses, batchSize).map(_ => theMap)
+        case Some(_: JavaMethod) =>
+          val allMethods = entities.filter(_.isInstanceOf[JavaMethod]).map{ case jm: JavaMethod => toMethodRepr(jm, theMap(jm.uid)) }.toSeq
+          batchedMethodInsert(allMethods, batchSize).map(_ => theMap)
+        case Some(_: JavaStatement) =>
+          val allInvocations = entities.filter(_.isInstanceOf[JavaInvokeStatement]).map { case jis: JavaInvokeStatement => toInvocationRepr(jis, theMap(jis.uid)) }.toSeq
+          val allFieldAccesses = entities.filter(_.isInstanceOf[JavaFieldAccessStatement]).map { case jfas: JavaFieldAccessStatement => toFieldAccessRepr(jfas, theMap(jfas.uid)) }.toSeq
+          batchedInvocationInsert(allInvocations, batchSize).andThen(_ => batchedFieldAccessInsert(allFieldAccesses, batchSize)).map(_ => theMap)
+        case _ =>
+          // Do nothing if there are no entities to insert or the entity kind does not need an extra table insert
+          Future.successful(Map.empty[String, Long])
+      }
     }
   }
 
-  private def storeInternal(data: JavaProgram, parentIdOpt: Option[Long]): Future[_] = {
-    val currentId = storeDataAndGetId(data, parentIdOpt)
-    log.debug(s"Storing java program ${data.name}")
-    storeProgram(data, currentId)
-  }
-
   private def storeDataAndGetId(data: SoftwareEntityData, parentIdOpt: Option[Long]): Long = {
-    //IMPROVE: More batching for performance improvement
     val res = idReturningEntitiesTable +=
       SoftwareEntityRepr(0, data.name, data.uid, data.language, data.kind.id, data.repository, parentIdOpt, data.binaryHash)
 
@@ -66,68 +95,6 @@ class PostgresStorageAdapter(implicit executor: ExecutionContext) extends Entity
   private def getIdForQualifier(fq: String): Long = {
     val queryFuture = db.run(entitiesTable.filter( row => row.qualifier === fq).take(1).map(_.id).result)
     Await.result(queryFuture, 10.seconds).head
-  }
-
-  private def storeProgram(jp: JavaProgram, programDbId: Long): Future[_] = {
-    val batch = jp.getChildren.map {
-      case jm: JavaPackage =>
-        toEntityRepr(jm, Some(programDbId))
-    }.toSeq
-
-    val insertAction = batchedEntityInsertWithMapReturn(batch, 100)
-
-    val insertResult = Await.result(insertAction, 10.seconds)
-
-    val classLookup = jp.getChildren.map(m => (m.uid, m.asInstanceOf[JavaPackage])).toMap
-
-    Future.sequence(insertResult.map( tuple => storePackage(classLookup(tuple._1), tuple._2)).toSeq)
-  }
-
-  private def storePackage(jp: JavaPackage, packageDbId: Long): Future[Unit] = {
-
-    var start = System.currentTimeMillis()
-    val allClasses = jp.getChildren.map { case jc: JavaClass => toEntityRepr(jc, Some(packageDbId))}.toSeq
-    val classLookup = Await.result(batchedEntityInsertWithMapReturn(allClasses, 500), 20.seconds)
-
-    Await.ready(batchedClassInsert(jp.getChildren.map { case jc: JavaClass =>
-      toClassRepr(jc, classLookup(jc.uid))}.toSeq, 500), 20.seconds)
-
-    var duration = System.currentTimeMillis() - start
-
-    log.debug(s"Stored all classes for package ${jp.uid} in $duration ms.")
-
-    start = System.currentTimeMillis()
-    val allMethods = jp.getChildren.flatMap( jc => jc.getChildren.map{ case jm: JavaMethod => toEntityRepr(jm, Some(classLookup(jc.uid)))}).toSeq
-    val methodLookup = Await.result(batchedEntityInsertWithMapReturn(allMethods, 500), 30.seconds)
-
-    Await.ready(batchedMethodInsert(jp.getChildren.flatMap(_.getChildren).map { case jm: JavaMethod =>
-      toMethodRepr(jm, methodLookup(jm.uid))}.toSeq, 500), 30.seconds)
-
-    duration = System.currentTimeMillis() - start
-
-    log.debug(s"Stored all methods for package ${jp.uid} in $duration ms.")
-
-    start = System.currentTimeMillis()
-    val allInstructions = jp.getChildren.flatMap(jc => jc.getChildren).flatMap(jm => jm.getChildren.map {
-      case js: JavaStatement => // Ensure integrity, only statements should be children of methods
-        toEntityRepr(js, Some(methodLookup(jm.uid)))
-    }).toSeq
-
-    val statementLookup = Await.result(batchedEntityInsertWithMapReturn(allInstructions, 500), 40.seconds)
-
-    val allInstructionsRaw = jp.getChildren.flatMap(_.getChildren).flatMap(_.getChildren)
-
-    val allInvocations = allInstructionsRaw.filter(_.isInstanceOf[JavaInvokeStatement]).map { case jis: JavaInvokeStatement => toInvocationRepr(jis, statementLookup(jis.uid))}.toSeq
-    val allFieldAccesses = allInstructionsRaw.filter(_.isInstanceOf[JavaFieldAccessStatement]).map { case jfas: JavaFieldAccessStatement => toFieldAccessRepr(jfas, statementLookup(jfas.uid))}.toSeq
-    // Note that JavaNewInstanceStatements do not need an extra table, their only piece of information is the type name, which is stored in the entity's 'Name' field
-
-    val result = Future.sequence(Seq(batchedInvocationInsert(allInvocations, 500), batchedFieldAccessInsert(allFieldAccesses, 500)))
-
-    duration = System.currentTimeMillis() - start
-
-    log.debug(s"Stored all instructions for package ${jp.uid} in $duration ms.")
-
-    result.map( _ => () )
   }
 
   private def toEntityRepr(data: SoftwareEntityData, parentIdOpt: Option[Long]): SoftwareEntityRepr = SoftwareEntityRepr(0, data.name,
@@ -143,15 +110,15 @@ class PostgresStorageAdapter(implicit executor: ExecutionContext) extends Entity
   private def toFieldAccessRepr(jfas: JavaFieldAccessStatement, parentId: Long): JavaFieldAccessRepr =
     (parentId, jfas.targetFieldTypeName, jfas.targetTypeName, jfas.fieldAccessType.id, jfas.instructionPc)
 
-  private def batchedEntityInsertWithMapReturn(entityReprs: Seq[SoftwareEntityRepr], batchSize: Int): Future[Map[String, Long]] = {
+  private def batchedEntityInsertWithMapReturn(entityReprs: Iterable[SoftwareEntityRepr], batchSize: Int): Future[Map[String, Long]] = {
 
-    Future.sequence(
-      entityReprs.grouped(batchSize).map { batch => db.run(qualifierAndIdReturningEntitiesTable ++= batch).map( resultObj => resultObj.toMap)}.toSeq)
+    Future
+      .sequence(
+        entityReprs
+          .grouped(batchSize)
+          .map { batch => db.run(qualifierAndIdReturningEntitiesTable ++= batch).map( resultObj => resultObj.toMap)}
+      )
       .map(seqOfMaps => seqOfMaps.flatten.toMap)
-  }
-
-  private def batchedEntityInsert(entityReprs: Seq[SoftwareEntityRepr], batchSize: Int): Future[Unit] = {
-    Future.sequence(entityReprs.grouped(batchSize).map { batch => db.run(entitiesTable ++= batch)}.toSeq).map( _ => ())
   }
 
   private def batchedClassInsert(data: Seq[JavaClassRepr], batchSize: Int): Future[Unit] = {
@@ -180,6 +147,12 @@ class PostgresStorageAdapter(implicit executor: ExecutionContext) extends Entity
     val setupFuture = db.run(setupAction)
 
     Await.ready(setupFuture, 20.seconds)
+
+    val s = db.createSession()
+    val autoCommit = s.conn.getAutoCommit
+    s.close()
+
+    log.info(s"Database setup complete, auto-commit value: $autoCommit")
   }
 
   override def shutdown(): Unit = db.close()


### PR DESCRIPTION
This PR brings a lot of improvements to the entity miner. Namely the large number of concurrently awaited futures has been removed. Also, should storage of a single program fail, it will be cleared from the DB before proceeding. The update also significantely improves the batching performance and tweaks the storage- and queue-poll timeouts.